### PR TITLE
[MSK-141] Cancel order in unlockCart

### DIFF
--- a/Model/Resolver/UnlockCart.php
+++ b/Model/Resolver/UnlockCart.php
@@ -135,6 +135,8 @@ class UnlockCart implements ResolverInterface
                 $orderStatus = 'canceled';
             }
 
+            // Ensure the order is canceled, release stock, etc.
+            $order->cancel();
             // Set the status and save the order
             $order->setStatus($orderStatus)->save();
         }


### PR DESCRIPTION
This pull request makes a targeted improvement to the order cancellation process in the `UnlockCart.php` resolver. The main change ensures that when an order is canceled, all associated cancellation logic (such as releasing stock) is properly executed.

Order cancellation process improvement:

* Explicitly calls `$order->cancel()` before setting the order status to `'canceled'`, ensuring that Magento's built-in cancellation logic (including stock release and other side effects) is triggered correctly. (`Model/Resolver/UnlockCart.php`)