### PR TITLE
[MSK-141] Get latest active order

### DIFF
--- a/Model/Resolver/UnlockCart.php
+++ b/Model/Resolver/UnlockCart.php
@@ -10,6 +10,7 @@ use Magento\Framework\GraphQl\Query\Resolver\ContextInterface;
 use Magento\Quote\Api\CartRepositoryInterface;
 use Magento\Quote\Model\QuoteFactory;
 use Magento\Sales\Model\OrderFactory;
+use Magento\Sales\Model\Order;
 use Tapbuy\CheckoutGraphql\Model\Authorization\TokenAuthorization;
 use Tapbuy\CheckoutGraphql\Helper\CartHelper;
 
@@ -110,10 +111,10 @@ class UnlockCart implements ResolverInterface
      */
     private function updateOrderStatus(string $quoteId, ?string $unlockReason): void
     {
-        $order = $this->orderFactory->create();
-        $order->getResource()->load($order, $quoteId, 'quote_id');
+        // Get the most recent order for this quote
+        $order = $this->getLatestOrderByQuoteId($quoteId);
 
-        if ($order->getId()) {
+        if ($order && $order->getId()) {
             // Definition of the unlock reason
             $msgTxt = "Tapbuy Unlock: ";
             if ($unlockReason === 'cancel') {
@@ -140,6 +141,26 @@ class UnlockCart implements ResolverInterface
             // Set the status and save the order
             $order->setStatus($orderStatus)->save();
         }
+    }
+
+    /**
+     * Get the latest active order for a given quote ID
+     *
+     * @param string $quoteId
+     * @return Order|null
+     */
+    private function getLatestOrderByQuoteId(string $quoteId): ?Order
+    {
+        $orderCollection = $this->orderFactory->create()->getCollection();
+        $orderCollection->addFieldToFilter('quote_id', $quoteId);
+        // Filter out canceled and complete orders
+        $orderCollection->addFieldToFilter('state', [
+            'nin' => [Order::STATE_CANCELED, Order::STATE_COMPLETE, Order::STATE_CLOSED]
+        ]);
+        $orderCollection->setOrder('created_at', 'DESC');
+        $orderCollection->setPageSize(1);
+
+        return $orderCollection->getFirstItem()->getId() ? $orderCollection->getFirstItem() : null;
     }
 
     /**

--- a/Model/Resolver/UnlockCart.php
+++ b/Model/Resolver/UnlockCart.php
@@ -160,7 +160,8 @@ class UnlockCart implements ResolverInterface
         $orderCollection->setOrder('created_at', 'DESC');
         $orderCollection->setPageSize(1);
 
-        return $orderCollection->getFirstItem()->getId() ? $orderCollection->getFirstItem() : null;
+        $order = $orderCollection->getFirstItem();
+        return $order->getId() ? $order : null;
     }
 
     /**

--- a/Model/Resolver/UnlockCart.php
+++ b/Model/Resolver/UnlockCart.php
@@ -9,7 +9,7 @@ use Magento\Framework\GraphQl\Config\Element\Field;
 use Magento\Framework\GraphQl\Query\Resolver\ContextInterface;
 use Magento\Quote\Api\CartRepositoryInterface;
 use Magento\Quote\Model\QuoteFactory;
-use Magento\Sales\Model\OrderFactory;
+use Magento\Sales\Model\ResourceModel\Order\CollectionFactory as OrderCollectionFactory;
 use Magento\Sales\Model\Order;
 use Tapbuy\CheckoutGraphql\Model\Authorization\TokenAuthorization;
 use Tapbuy\CheckoutGraphql\Helper\CartHelper;
@@ -22,9 +22,9 @@ class UnlockCart implements ResolverInterface
     private $tokenAuthorization;
 
     /**
-     * @var OrderFactory
+     * @var OrderCollectionFactory
      */
-    private $orderFactory;
+    private $orderCollectionFactory;
 
     /**
      * @var CartRepositoryInterface
@@ -43,20 +43,20 @@ class UnlockCart implements ResolverInterface
 
     /**
      * @param TokenAuthorization $tokenAuthorization
-     * @param OrderFactory $orderFactory
+     * @param OrderCollectionFactory $orderCollectionFactory
      * @param CartRepositoryInterface $cartRepository
      * @param QuoteFactory $quoteFactory
      * @param CartHelper $cartHelper
      */
     public function __construct(
         TokenAuthorization $tokenAuthorization,
-        OrderFactory $orderFactory,
+        OrderCollectionFactory $orderCollectionFactory,
         CartRepositoryInterface $cartRepository,
         QuoteFactory $quoteFactory,
         CartHelper $cartHelper
     ) {
         $this->tokenAuthorization = $tokenAuthorization;
-        $this->orderFactory = $orderFactory;
+        $this->orderCollectionFactory = $orderCollectionFactory;
         $this->cartRepository = $cartRepository;
         $this->quoteFactory = $quoteFactory;
         $this->cartHelper = $cartHelper;
@@ -151,7 +151,7 @@ class UnlockCart implements ResolverInterface
      */
     private function getLatestOrderByQuoteId(string $quoteId): ?Order
     {
-        $orderCollection = $this->orderFactory->create()->getCollection();
+        $orderCollection = $this->orderCollectionFactory->create();
         $orderCollection->addFieldToFilter('quote_id', $quoteId);
         // Filter out canceled and complete orders
         $orderCollection->addFieldToFilter('state', [


### PR DESCRIPTION
This pull request improves the way orders are retrieved and updated during the cart unlock process in `UnlockCart.php`. The main change is to ensure that only the most recent and active order associated with a quote is updated, preventing updates to canceled or completed orders.

Order retrieval improvements:

* Added a new private method `getLatestOrderByQuoteId` to fetch the most recent active order for a given quote ID, filtering out canceled, complete, and closed orders, and ensuring only the latest order is considered. (Fa1aa822L143)
* Updated the `updateOrderStatus` method to use the new `getLatestOrderByQuoteId` method instead of directly loading an order by quote ID, ensuring only valid orders are updated. (Fa1aa822L111)

Dependency updates:

* Added an explicit import for the `Order` class to support type hinting and filtering. (Fa1aa822L10)