### PR TITLE
[CHAN-32] Parent SKU

### DIFF
--- a/Model/Resolver/Product/ParentSku.php
+++ b/Model/Resolver/Product/ParentSku.php
@@ -1,0 +1,88 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tapbuy\CheckoutGraphql\Model\Resolver\Product;
+
+use Magento\Catalog\Api\ProductRepositoryInterface;
+use Magento\ConfigurableProduct\Model\ResourceModel\Product\Type\Configurable as ConfigurableType;
+use Magento\Framework\Exception\NoSuchEntityException;
+use Magento\Framework\GraphQl\Config\Element\Field;
+use Magento\Framework\GraphQl\Query\ResolverInterface;
+use Magento\Framework\GraphQl\Schema\Type\ResolveInfo;
+
+/**
+ * Resolver for parent_sku field on ProductInterface.
+ *
+ * Returns the SKU of the parent configurable product for simple products
+ * that are variants of a configurable product.
+ */
+class ParentSku implements ResolverInterface
+{
+    /**
+     * @var ConfigurableType
+     */
+    private ConfigurableType $configurableType;
+
+    /**
+     * @var ProductRepositoryInterface
+     */
+    private ProductRepositoryInterface $productRepository;
+
+    /**
+     * @param ConfigurableType $configurableType
+     * @param ProductRepositoryInterface $productRepository
+     */
+    public function __construct(
+        ConfigurableType $configurableType,
+        ProductRepositoryInterface $productRepository
+    ) {
+        $this->configurableType = $configurableType;
+        $this->productRepository = $productRepository;
+    }
+
+    /**
+     * Resolves the parent_sku field for a product.
+     *
+     * @param Field $field
+     * @param mixed $context
+     * @param ResolveInfo $info
+     * @param array|null $value
+     * @param array|null $args
+     * @return string|null The parent SKU or null if not a child product
+     */
+    public function resolve(
+        Field $field,
+        $context,
+        ResolveInfo $info,
+        ?array $value = null,
+        ?array $args = null
+    ): ?string {
+        if (!isset($value['model'])) {
+            return null;
+        }
+
+        /** @var \Magento\Catalog\Model\Product $product */
+        $product = $value['model'];
+
+        // Only simple products can have a parent configurable product
+        if ($product->getTypeId() !== 'simple') {
+            return null;
+        }
+
+        // Get parent configurable product IDs for this simple product
+        $parentIds = $this->configurableType->getParentIdsByChild($product->getId());
+
+        if (empty($parentIds)) {
+            return null;
+        }
+
+        // Get the first parent product (a simple product typically has one parent)
+        try {
+            $parentProduct = $this->productRepository->getById((int) $parentIds[0]);
+            return $parentProduct->getSku();
+        } catch (NoSuchEntityException $e) {
+            return null;
+        }
+    }
+}

--- a/etc/schema.graphqls
+++ b/etc/schema.graphqls
@@ -101,3 +101,7 @@ type TapbuyOrderAssignCustomerOutput {
     success: Boolean! @doc(description: "Indicates if the order was successfully assigned")
     order: CustomerOrder @doc(description: "Order data after reassignment")
 }
+
+interface ProductInterface {
+    tapbuy_parent_sku: String @resolver(class: "Tapbuy\\CheckoutGraphql\\Model\\Resolver\\Product\\ParentSku") @doc(description: "The SKU of the parent configurable product for simple products that are variants")
+}


### PR DESCRIPTION
This pull request introduces a new GraphQL resolver to expose the parent configurable product SKU for simple products in the Magento GraphQL API. The main changes include implementing a resolver class and updating the GraphQL schema to add a new field to the product interface.

**GraphQL API Enhancements:**

* Added a new resolver class `ParentSku` in `Model/Resolver/Product/ParentSku.php` that returns the SKU of the parent configurable product for simple products. This resolver checks if the product is a simple product, finds its parent configurable product (if any), and returns the parent's SKU.
* Updated the GraphQL schema in `etc/schema.graphqls` to add a new field `tapbuy_parent_sku` to the `ProductInterface`. This field uses the new resolver and provides the parent configurable SKU for simple products that are variants of a configurable product.