### PR TITLE
[PDT-491] Replace hardcoded strings with constants

### DIFF
--- a/Plugin/SetPaymentMethodOnCartPlugin.php
+++ b/Plugin/SetPaymentMethodOnCartPlugin.php
@@ -8,6 +8,7 @@ use Magento\Framework\GraphQl\Schema\Type\ResolveInfo;
 use Magento\Quote\Api\CartRepositoryInterface;
 use Magento\Quote\Model\QuoteIdMaskFactory;
 use Magento\Framework\Serialize\SerializerInterface;
+use Tapbuy\RedirectTracking\Api\TapbuyConstants;
 use Tapbuy\RedirectTracking\Logger\TapbuyLogger;
 
 class SetPaymentMethodOnCartPlugin
@@ -97,7 +98,7 @@ class SetPaymentMethodOnCartPlugin
         $payment = $quote->getPayment();
 
         $payment->setAdditionalInformation(
-            'tapbuy',
+            TapbuyConstants::PAYMENT_ADDITIONAL_INFO_KEY,
             $this->serializer->serialize($additionalInfo)
         );
         $this->cartRepository->save($quote);


### PR DESCRIPTION
This pull request makes a small but important change to how the Tapbuy payment information is stored on the cart. Instead of using a hardcoded string for the additional information key, it now uses a constant from `TapbuyConstants` for better maintainability and consistency.

- Payment Information Handling:
  * Updated `SetPaymentMethodOnCartPlugin.php` to use `TapbuyConstants::PAYMENT_ADDITIONAL_INFO_KEY` instead of the hardcoded `'tapbuy'` string when setting additional payment information on the cart.
  * Added the `Tapbuy\RedirectTracking\Api\TapbuyConstants` import to support the new constant usage.