### PR TITLE
[PDT-494] Add early exit to plugins when header X-Tapbuy-Call is absent

### DIFF
--- a/Plugin/SetPaymentMethodOnCartPlugin.php
+++ b/Plugin/SetPaymentMethodOnCartPlugin.php
@@ -10,6 +10,7 @@ use Magento\Quote\Model\QuoteIdMaskFactory;
 use Magento\Framework\Serialize\SerializerInterface;
 use Tapbuy\RedirectTracking\Api\LoggerInterface;
 use Tapbuy\RedirectTracking\Api\TapbuyConstants;
+use Tapbuy\RedirectTracking\Api\TapbuyRequestDetectorInterface;
 
 class SetPaymentMethodOnCartPlugin
 {
@@ -33,16 +34,23 @@ class SetPaymentMethodOnCartPlugin
      */
     private $logger;
 
+    /**
+     * @var TapbuyRequestDetectorInterface
+     */
+    private $requestDetector;
+
     public function __construct(
         CartRepositoryInterface $cartRepository,
         QuoteIdMaskFactory $quoteIdMaskFactory,
         SerializerInterface $serializer,
-        LoggerInterface $logger
+        LoggerInterface $logger,
+        TapbuyRequestDetectorInterface $requestDetector
     ) {
         $this->cartRepository = $cartRepository;
         $this->quoteIdMaskFactory = $quoteIdMaskFactory;
         $this->serializer = $serializer;
         $this->logger = $logger;
+        $this->requestDetector = $requestDetector;
     }
 
     /**
@@ -64,6 +72,11 @@ class SetPaymentMethodOnCartPlugin
         array $value = null,
         array $args = null
     ) {
+        // Early return for non-Tapbuy requests to avoid unnecessary processing
+        if (!$this->requestDetector->isTapbuyCall()) {
+            return $result;
+        }
+
         try {
             $cartId = $args['input']['cart_id'] ?? null;
             $paymentMethod = $args['input']['payment_method'] ?? null;


### PR DESCRIPTION
This pull request updates the `SetPaymentMethodOnCartPlugin` to improve how it handles requests by introducing a new dependency and optimizing request processing. The main change is the addition of a request detector to ensure that Tapbuy-specific logic only runs for relevant requests, reducing unnecessary processing and potential side effects.

**Dependency injection and request handling improvements:**

* Added a dependency on `TapbuyRequestDetectorInterface` to the plugin constructor, storing it as a private member for use in request detection. [[1]](diffhunk://#diff-f0bdfee3e6d4b600f784229b13d8b59331d3591120ee7209e9adbc22c24c0dddR13) [[2]](diffhunk://#diff-f0bdfee3e6d4b600f784229b13d8b59331d3591120ee7209e9adbc22c24c0dddR37-R53)
* Updated the `afterResolve` method to return early for non-Tapbuy requests by checking with the new `requestDetector`, preventing unnecessary Tapbuy logic from running on unrelated requests.