### PR TITLE
PDT-490 Declare strict type

### DIFF
--- a/Api/CartHelperInterface.php
+++ b/Api/CartHelperInterface.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Tapbuy Cart Helper Interface
  *

--- a/Api/OrderDataFormatterInterface.php
+++ b/Api/OrderDataFormatterInterface.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Tapbuy Order Data Formatter Interface
  *

--- a/Api/OrderLocatorInterface.php
+++ b/Api/OrderLocatorInterface.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Tapbuy Order Locator Interface
  *

--- a/Helper/CartHelper.php
+++ b/Helper/CartHelper.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Tapbuy\CheckoutGraphql\Helper;
 
 use Magento\Quote\Model\QuoteIdMaskFactory;

--- a/Model/OrderDataFormatter.php
+++ b/Model/OrderDataFormatter.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Tapbuy\CheckoutGraphql\Model;
 
 use Magento\Sales\Api\Data\OrderInterface;

--- a/Model/OrderLocator.php
+++ b/Model/OrderLocator.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Tapbuy\CheckoutGraphql\Model;
 
 use Magento\Framework\Api\SearchCriteriaBuilderFactory;

--- a/Model/Resolver/Customer.php
+++ b/Model/Resolver/Customer.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Tapbuy\CheckoutGraphql\Model\Resolver;
 
 use Magento\Framework\GraphQl\Config\Element\Field;

--- a/Model/Resolver/CustomerSearch.php
+++ b/Model/Resolver/CustomerSearch.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Tapbuy\CheckoutGraphql\Model\Resolver;
 
 use Magento\Framework\GraphQl\Query\ResolverInterface;

--- a/Model/Resolver/DeactivateCart.php
+++ b/Model/Resolver/DeactivateCart.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Tapbuy\CheckoutGraphql\Model\Resolver;
 
 use Magento\Framework\GraphQl\Query\ResolverInterface;

--- a/Model/Resolver/GetOrder.php
+++ b/Model/Resolver/GetOrder.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Tapbuy\CheckoutGraphql\Model\Resolver;
 
 use Magento\Framework\GraphQl\Config\Element\Field;

--- a/Model/Resolver/GetOrderItems.php
+++ b/Model/Resolver/GetOrderItems.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copied directly from the Magento resolver.
  * The only change is that the authorized customer check is removed.

--- a/Model/Resolver/ModulesVersions.php
+++ b/Model/Resolver/ModulesVersions.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Tapbuy\CheckoutGraphql\Model\Resolver;
 
 use Magento\Framework\Component\ComponentRegistrar;

--- a/Model/Resolver/OrderAddress.php
+++ b/Model/Resolver/OrderAddress.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Tapbuy\CheckoutGraphql\Model\Resolver;
 
 use Magento\Framework\GraphQl\Config\Element\Field;

--- a/Model/Resolver/OrderAssignCustomer.php
+++ b/Model/Resolver/OrderAssignCustomer.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Tapbuy\CheckoutGraphql\Model\Resolver;
 
 use Magento\Customer\Api\CustomerRepositoryInterface;

--- a/Model/Resolver/OrderPaymentMethod.php
+++ b/Model/Resolver/OrderPaymentMethod.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Tapbuy\CheckoutGraphql\Model\Resolver;
 
 use Magento\Framework\GraphQl\Config\Element\Field;

--- a/Model/Resolver/UnlockCart.php
+++ b/Model/Resolver/UnlockCart.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Tapbuy\CheckoutGraphql\Model\Resolver;
 
 use Magento\Framework\GraphQl\Query\ResolverInterface;

--- a/Plugin/SetPaymentMethodOnCartPlugin.php
+++ b/Plugin/SetPaymentMethodOnCartPlugin.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Tapbuy\CheckoutGraphql\Plugin;
 
 use Magento\QuoteGraphQl\Model\Resolver\SetPaymentMethodOnCart;

--- a/registration.php
+++ b/registration.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 \Magento\Framework\Component\ComponentRegistrar::register(
     \Magento\Framework\Component\ComponentRegistrar::MODULE,
     'Tapbuy_CheckoutGraphql',


### PR DESCRIPTION
This pull request introduces strict typing across the codebase by adding `declare(strict_types=1);` to all PHP files in the module. This change enforces stricter type checking at runtime, which helps catch type-related bugs early and improves overall code quality.

**Strict typing enforcement:**

* Added `declare(strict_types=1);` to all interface files, including `CartHelperInterface.php`, `OrderDataFormatterInterface.php`, and `OrderLocatorInterface.php` to ensure strict type checking for all contracts. [[1]](diffhunk://#diff-dc2b002ff976141b72da52499208d5bfa47eef73d34d1688e59f76a0caefec62R3-R4) [[2]](diffhunk://#diff-52081a4aa58b05f027312ac9491ed119b85576b1e1ae8466f51192bef9df2607R3-R4) [[3]](diffhunk://#diff-adbcebe2564f7fb8f613f352a522f4349419f08109f63e904894462004660d00R3-R4)
* Added `declare(strict_types=1);` to all model and helper implementation files, such as `CartHelper.php`, `OrderDataFormatter.php`, and `OrderLocator.php`, to enforce strict types in business logic. [[1]](diffhunk://#diff-605aee0063fad8751d75dff003fa00940642b165865f22533c94d0eae4161924R3-R4) [[2]](diffhunk://#diff-23338816e403053c303e1544085f76e5a9049f64f4ddd18f2a1a0ed645da4f23R3-R4) [[3]](diffhunk://#diff-0bdfda4af93c960384f5373328ad7c24f1fd3827e15e148f38a899f60b220b92R3-R4)
* Applied `declare(strict_types=1);` to all GraphQL resolver files, including `Customer.php`, `CustomerSearch.php`, `DeactivateCart.php`, `GetOrder.php`, `GetOrderItems.php`, `ModulesVersions.php`, `OrderAddress.php`, `OrderAssignCustomer.php`, `OrderPaymentMethod.php`, and `UnlockCart.php`, ensuring strict type checking in GraphQL layer. [[1]](diffhunk://#diff-925451851b60ade7bfb4f947e0ea9b0aff9c3de3e96b41b6258ae97eb2f77e9bR3-R4) [[2]](diffhunk://#diff-6a2ac6e45603682cbed7d6b88d95c75ec63bdcb716a8731bcdd28c4bd33790fbR3-R4) [[3]](diffhunk://#diff-4209a602de23724a1b9bc8cb820f08b4fa741f2b1b93f3a3243505f818a14051R3-R4) [[4]](diffhunk://#diff-1f688f23ef81fb6bdec3066dc420fb0cf410f5e5481e5e69a99af347a5a9807dR3-R4) [[5]](diffhunk://#diff-ed8e05b97c9d2c74ce0f3295e11710624187e6935f90731ed0c0634cc8fe7b74R3-R4) [[6]](diffhunk://#diff-dc67624c372e359705498116b047c984cbec8d85e80a469d98f9f90644bccb34R3-R4) [[7]](diffhunk://#diff-8ee4b7d2ae307c255ed83c34611fc75abd17e999c6a67beb19ff4bd29aa499f9R3-R4) [[8]](diffhunk://#diff-9e88fcc9ed181eb71c874e6cb155c21edc52cf4327c99ade9b5bb1256f537635R3-R4) [[9]](diffhunk://#diff-abb9e10273116484ac84de786224ed01d85fcf43d841b25461bcb729440459deR3-R4) [[10]](diffhunk://#diff-f691a6b674f33e9a739e3c68cd64214d014f08b870917c2b4ca61e22cf4c7c0eR3-R4)
* Added `declare(strict_types=1);` to the plugin file `SetPaymentMethodOnCartPlugin.php` for stricter type enforcement in plugin logic.
* Updated the module registration file `registration.php` to include strict typing.