### PR TITLE
PDT-467 Early module activation checks

### DIFF
--- a/Model/Resolver/Customer.php
+++ b/Model/Resolver/Customer.php
@@ -9,6 +9,7 @@ use Magento\Framework\GraphQl\Query\Resolver\ContextInterface;
 use Magento\Framework\GraphQl\Query\ResolverInterface;
 use Magento\Framework\GraphQl\Schema\Type\ResolveInfo;
 use Tapbuy\RedirectTracking\Api\Authorization\TokenAuthorizationInterface;
+use Tapbuy\RedirectTracking\Api\ConfigInterface;
 
 class Customer implements ResolverInterface
 {
@@ -23,12 +24,20 @@ class Customer implements ResolverInterface
     private $tokenAuthorization;
 
     /**
+     * @var ConfigInterface
+     */
+    private $config;
+
+    /**
      * @param TokenAuthorizationInterface $tokenAuthorization
+     * @param ConfigInterface $config
      */
     public function __construct(
-        TokenAuthorizationInterface $tokenAuthorization
+        TokenAuthorizationInterface $tokenAuthorization,
+        ConfigInterface $config
     ) {
         $this->tokenAuthorization = $tokenAuthorization;
+        $this->config = $config;
     }
 
     /**
@@ -52,6 +61,10 @@ class Customer implements ResolverInterface
         ?array $value = null,
         ?array $args = null
     ) {
+        if (!$this->config->isEnabled()) {
+            return null;
+        }
+
         $this->tokenAuthorization->authorize(self::ACL_RESOURCE);
 
         if (!isset($value['model'])) {

--- a/Model/Resolver/CustomerSearch.php
+++ b/Model/Resolver/CustomerSearch.php
@@ -13,6 +13,7 @@ use Magento\Framework\GraphQl\Query\Resolver\ContextInterface;
 use Magento\Framework\Exception\NoSuchEntityException;
 use Magento\CustomerGraphQl\Model\Customer\ExtractCustomerData;
 use Tapbuy\RedirectTracking\Api\Authorization\TokenAuthorizationInterface;
+use Tapbuy\RedirectTracking\Api\ConfigInterface;
 
 class CustomerSearch implements ResolverInterface
 {
@@ -37,6 +38,11 @@ class CustomerSearch implements ResolverInterface
     private $tokenAuthorization;
 
     /**
+     * @var ConfigInterface
+     */
+    private $config;
+
+    /**
      * @param CustomerRepositoryInterface $customerRepository
      * @param ExtractCustomerData $extractCustomerData
      * @param TokenAuthorizationInterface $tokenAuthorization
@@ -45,10 +51,12 @@ class CustomerSearch implements ResolverInterface
         CustomerRepositoryInterface $customerRepository,
         ExtractCustomerData $extractCustomerData,
         TokenAuthorizationInterface $tokenAuthorization,
+        ConfigInterface $config
     ) {
         $this->customerRepository = $customerRepository;
         $this->extractCustomerData = $extractCustomerData;
         $this->tokenAuthorization = $tokenAuthorization;
+        $this->config = $config;
     }
 
     /**
@@ -73,6 +81,10 @@ class CustomerSearch implements ResolverInterface
         ?array $value = null,
         ?array $args = null
     ) {
+        if (!$this->config->isEnabled()) {
+            throw new GraphQlInputException(__('Tapbuy is disabled.'));
+        }
+
         $this->tokenAuthorization->authorize(self::ACL_RESOURCE);
 
         if (empty($args['email'])) {

--- a/Model/Resolver/DeactivateCart.php
+++ b/Model/Resolver/DeactivateCart.php
@@ -12,6 +12,7 @@ use Magento\Framework\GraphQl\Query\Resolver\ContextInterface;
 use Magento\Quote\Api\CartRepositoryInterface;
 use Tapbuy\RedirectTracking\Api\Authorization\TokenAuthorizationInterface;
 use Tapbuy\RedirectTracking\Api\Cart\CartResolverInterface;
+use Tapbuy\RedirectTracking\Api\ConfigInterface;
 use Tapbuy\RedirectTracking\Api\LoggerInterface;
 
 class DeactivateCart implements ResolverInterface
@@ -37,6 +38,11 @@ class DeactivateCart implements ResolverInterface
     private $cartResolver;
 
     /**
+     * @var ConfigInterface
+     */
+    private $config;
+
+    /**
      * @var LoggerInterface
      */
     private $logger;
@@ -45,17 +51,20 @@ class DeactivateCart implements ResolverInterface
      * @param TokenAuthorizationInterface $tokenAuthorization
      * @param CartRepositoryInterface $cartRepository
      * @param CartResolverInterface $cartResolver
+     * @param ConfigInterface $config
      * @param LoggerInterface $logger
      */
     public function __construct(
         TokenAuthorizationInterface $tokenAuthorization,
         CartRepositoryInterface $cartRepository,
         CartResolverInterface $cartResolver,
+        ConfigInterface $config,
         LoggerInterface $logger
     ) {
         $this->tokenAuthorization = $tokenAuthorization;
         $this->cartRepository = $cartRepository;
         $this->cartResolver = $cartResolver;
+        $this->config = $config;
         $this->logger = $logger;
     }
 
@@ -77,6 +86,10 @@ class DeactivateCart implements ResolverInterface
         ?array $value = null,
         ?array $args = null
     ) {
+        if (!$this->config->isEnabled()) {
+            throw new GraphQlInputException(__('Tapbuy is disabled.'));
+        }
+
         $this->tokenAuthorization->authorize(self::ACL_RESOURCE);
 
         if (empty($args['cart_id'])) {

--- a/Model/Resolver/GetOrder.php
+++ b/Model/Resolver/GetOrder.php
@@ -11,6 +11,7 @@ use Magento\Framework\GraphQl\Query\Resolver\ContextInterface;
 use Magento\Framework\GraphQl\Query\ResolverInterface;
 use Magento\Framework\GraphQl\Schema\Type\ResolveInfo;
 use Tapbuy\RedirectTracking\Api\Authorization\TokenAuthorizationInterface;
+use Tapbuy\RedirectTracking\Api\ConfigInterface;
 use Tapbuy\CheckoutGraphql\Api\OrderDataFormatterInterface;
 use Tapbuy\RedirectTracking\Api\Order\OrderLocatorInterface;
 use Magento\Framework\Exception\NoSuchEntityException;
@@ -28,8 +29,14 @@ class GetOrder implements ResolverInterface
     private $tokenAuthorization;
 
     /**
+     * @var ConfigInterface
+     */
+    private $config;
+
+    /**
      * @var OrderDataFormatterInterface
      */
+
     private $orderFormatter;
 
     /**
@@ -41,15 +48,18 @@ class GetOrder implements ResolverInterface
      * @param TokenAuthorizationInterface $tokenAuthorization
      * @param OrderDataFormatterInterface $orderFormatter
      * @param OrderLocatorInterface $orderLocator
+     * @param ConfigInterface $config
      */
     public function __construct(
         TokenAuthorizationInterface $tokenAuthorization,
         OrderDataFormatterInterface $orderFormatter,
-        OrderLocatorInterface $orderLocator
+        OrderLocatorInterface $orderLocator,
+        ConfigInterface $config
     ) {
         $this->tokenAuthorization = $tokenAuthorization;
         $this->orderFormatter = $orderFormatter;
         $this->orderLocator = $orderLocator;
+        $this->config = $config;
     }
 
     /**
@@ -74,6 +84,10 @@ class GetOrder implements ResolverInterface
         ?array $value = null,
         ?array $args = null
     ) {
+        if (!$this->config->isEnabled()) {
+            throw new GraphQlInputException(__('Tapbuy is disabled.'));
+        }
+
         $this->tokenAuthorization->authorize(self::ACL_RESOURCE);
 
         if (empty($args['order_number']) && empty($args['order_id'])) {

--- a/Model/Resolver/GetOrder.php
+++ b/Model/Resolver/GetOrder.php
@@ -36,7 +36,6 @@ class GetOrder implements ResolverInterface
     /**
      * @var OrderDataFormatterInterface
      */
-
     private $orderFormatter;
 
     /**

--- a/Model/Resolver/GetOrderItems.php
+++ b/Model/Resolver/GetOrderItems.php
@@ -17,6 +17,7 @@ use Magento\Framework\GraphQl\Schema\Type\ResolveInfo;
 use Magento\Sales\Api\Data\OrderInterface;
 use Magento\SalesGraphQl\Model\OrderItem\DataProvider as OrderItemProvider;
 use Tapbuy\RedirectTracking\Api\Authorization\TokenAuthorizationInterface;
+use Tapbuy\RedirectTracking\Api\ConfigInterface;
 
 /**
  * Resolve order items for order.
@@ -34,6 +35,11 @@ class GetOrderItems implements ResolverInterface
     private $tokenAuthorization;
 
     /**
+     * @var ConfigInterface
+     */
+    private $config;
+
+    /**
      * @var ValueFactory
      */
     private $valueFactory;
@@ -47,15 +53,18 @@ class GetOrderItems implements ResolverInterface
      * @param TokenAuthorizationInterface $tokenAuthorization
      * @param ValueFactory $valueFactory
      * @param OrderItemProvider $orderItemProvider
+     * @param ConfigInterface $config
      */
     public function __construct(
         TokenAuthorizationInterface $tokenAuthorization,
         ValueFactory $valueFactory,
-        OrderItemProvider $orderItemProvider
+        OrderItemProvider $orderItemProvider,
+        ConfigInterface $config
     ) {
         $this->tokenAuthorization = $tokenAuthorization;
         $this->valueFactory = $valueFactory;
         $this->orderItemProvider = $orderItemProvider;
+        $this->config = $config;
     }
 
     /**
@@ -72,6 +81,10 @@ class GetOrderItems implements ResolverInterface
      */
     public function resolve(Field $field, $context, ResolveInfo $info, array $value = null, array $args = null)
     {
+        if (!$this->config->isEnabled()) {
+            return [];
+        }
+
         $this->tokenAuthorization->authorize(self::ACL_RESOURCE);
 
         if (!(($value['model'] ?? null) instanceof OrderInterface)) {

--- a/Model/Resolver/ModulesVersions.php
+++ b/Model/Resolver/ModulesVersions.php
@@ -5,12 +5,10 @@ declare(strict_types=1);
 namespace Tapbuy\CheckoutGraphql\Model\Resolver;
 
 use Magento\Framework\Component\ComponentRegistrar;
-use Magento\Framework\Exception\FileSystemException;
 use Magento\Framework\Filesystem\Driver\File;
 use Magento\Framework\GraphQl\Config\Element\Field;
 use Magento\Framework\GraphQl\Query\Resolver\ContextInterface;
 use Magento\Framework\GraphQl\Query\ResolverInterface;
-use Magento\Framework\GraphQl\Exception\GraphQlInputException;
 use Magento\Framework\GraphQl\Schema\Type\ResolveInfo;
 use Magento\Framework\Serialize\Serializer\Json;
 use Magento\Framework\Module\Manager as ModuleManager;
@@ -113,7 +111,7 @@ class ModulesVersions implements ResolverInterface
         $tapbuyModules = [];
 
         if (!$this->config->isEnabled()) {
-            $tapbuyModules[] = ['name' => 'Tapbuy', 'version' => 'Tapbuy configuration is disabled', 'enabled' => false];
+            $tapbuyModules[] = ['name' => 'Tapbuy configuration is disabled', 'version' => 'N/A', 'enabled' => false];
         }
 
         $allModules = $this->componentRegistrar->getPaths(ComponentRegistrar::MODULE);

--- a/Model/Resolver/ModulesVersions.php
+++ b/Model/Resolver/ModulesVersions.php
@@ -10,10 +10,12 @@ use Magento\Framework\Filesystem\Driver\File;
 use Magento\Framework\GraphQl\Config\Element\Field;
 use Magento\Framework\GraphQl\Query\Resolver\ContextInterface;
 use Magento\Framework\GraphQl\Query\ResolverInterface;
+use Magento\Framework\GraphQl\Exception\GraphQlInputException;
 use Magento\Framework\GraphQl\Schema\Type\ResolveInfo;
 use Magento\Framework\Serialize\Serializer\Json;
 use Magento\Framework\Module\Manager as ModuleManager;
 use Tapbuy\RedirectTracking\Api\Authorization\TokenAuthorizationInterface;
+use Tapbuy\RedirectTracking\Api\ConfigInterface;
 use Tapbuy\RedirectTracking\Api\LoggerInterface;
 
 class ModulesVersions implements ResolverInterface
@@ -27,6 +29,11 @@ class ModulesVersions implements ResolverInterface
      * @var TokenAuthorizationInterface
      */
     private $tokenAuthorization;
+
+    /**
+     * @var ConfigInterface
+     */
+    private $config;
 
     /**
      * @var ComponentRegistrar
@@ -59,6 +66,7 @@ class ModulesVersions implements ResolverInterface
      * @param File $file
      * @param Json $json
      * @param ModuleManager $moduleManager
+     * @param ConfigInterface $config
      * @param LoggerInterface $logger
      */
     public function __construct(
@@ -67,6 +75,7 @@ class ModulesVersions implements ResolverInterface
         File $file,
         Json $json,
         ModuleManager $moduleManager,
+        ConfigInterface $config,
         LoggerInterface $logger
     ) {
         $this->tokenAuthorization = $tokenAuthorization;
@@ -74,6 +83,7 @@ class ModulesVersions implements ResolverInterface
         $this->file = $file;
         $this->json = $json;
         $this->moduleManager = $moduleManager;
+        $this->config = $config;
         $this->logger = $logger;
     }
 
@@ -101,6 +111,11 @@ class ModulesVersions implements ResolverInterface
         $this->tokenAuthorization->authorize(self::ACL_RESOURCE);
 
         $tapbuyModules = [];
+
+        if (!$this->config->isEnabled()) {
+            $tapbuyModules[] = ['name' => 'Tapbuy', 'version' => 'Tapbuy configuration is disabled', 'enabled' => false];
+        }
+
         $allModules = $this->componentRegistrar->getPaths(ComponentRegistrar::MODULE);
 
         foreach ($allModules as $moduleName => $modulePath) {

--- a/Model/Resolver/OrderAddress.php
+++ b/Model/Resolver/OrderAddress.php
@@ -9,6 +9,7 @@ use Magento\Framework\GraphQl\Query\Resolver\ContextInterface;
 use Magento\Framework\GraphQl\Query\ResolverInterface;
 use Magento\Framework\GraphQl\Schema\Type\ResolveInfo;
 use Tapbuy\RedirectTracking\Api\Authorization\TokenAuthorizationInterface;
+use Tapbuy\RedirectTracking\Api\ConfigInterface;
 
 class OrderAddress implements ResolverInterface
 {
@@ -23,12 +24,20 @@ class OrderAddress implements ResolverInterface
     private $tokenAuthorization;
 
     /**
+     * @var ConfigInterface
+     */
+    private $config;
+
+    /**
      * @param TokenAuthorizationInterface $tokenAuthorization
+     * @param ConfigInterface $config
      */
     public function __construct(
-        TokenAuthorizationInterface $tokenAuthorization
+        TokenAuthorizationInterface $tokenAuthorization,
+        ConfigInterface $config
     ) {
         $this->tokenAuthorization = $tokenAuthorization;
+        $this->config = $config;
     }
 
     /**
@@ -48,6 +57,10 @@ class OrderAddress implements ResolverInterface
         ?array $value = null,
         ?array $args = null
     ) {
+        if (!$this->config->isEnabled()) {
+            return null;
+        }
+
         $this->tokenAuthorization->authorize(self::ACL_RESOURCE);
 
         if (!isset($value['model'])) {

--- a/Model/Resolver/OrderAssignCustomer.php
+++ b/Model/Resolver/OrderAssignCustomer.php
@@ -15,6 +15,7 @@ use Magento\Framework\GraphQl\Query\ResolverInterface;
 use Magento\Framework\GraphQl\Schema\Type\ResolveInfo;
 use Magento\Sales\Model\Order\CustomerAssignment;
 use Tapbuy\RedirectTracking\Api\Authorization\TokenAuthorizationInterface;
+use Tapbuy\RedirectTracking\Api\ConfigInterface;
 use Tapbuy\CheckoutGraphql\Api\OrderDataFormatterInterface;
 use Tapbuy\RedirectTracking\Api\Order\OrderLocatorInterface;
 
@@ -29,6 +30,11 @@ class OrderAssignCustomer implements ResolverInterface
      * @var TokenAuthorizationInterface
      */
     private $tokenAuthorization;
+
+    /**
+     * @var ConfigInterface
+     */
+    private $config;
 
     /**
      * @var OrderDataFormatterInterface
@@ -56,19 +62,22 @@ class OrderAssignCustomer implements ResolverInterface
      * @param CustomerRepositoryInterface $customerRepository
      * @param CustomerAssignment $customerAssignment
      * @param OrderLocatorInterface $orderLocator
+     * @param ConfigInterface $config
      */
     public function __construct(
         TokenAuthorizationInterface $tokenAuthorization,
         OrderDataFormatterInterface $orderFormatter,
         CustomerRepositoryInterface $customerRepository,
         CustomerAssignment $customerAssignment,
-        OrderLocatorInterface $orderLocator
+        OrderLocatorInterface $orderLocator,
+        ConfigInterface $config
     ) {
         $this->tokenAuthorization = $tokenAuthorization;
         $this->orderFormatter = $orderFormatter;
         $this->customerRepository = $customerRepository;
         $this->customerAssignment = $customerAssignment;
         $this->orderLocator = $orderLocator;
+        $this->config = $config;
     }
 
     /**
@@ -90,6 +99,10 @@ class OrderAssignCustomer implements ResolverInterface
         ?array $value = null,
         ?array $args = null
     ) {
+        if (!$this->config->isEnabled()) {
+            throw new GraphQlInputException(__('Tapbuy is disabled.'));
+        }
+
         $this->tokenAuthorization->authorize(self::ACL_RESOURCE);
 
         if (empty($args['order_id'])) {

--- a/Model/Resolver/OrderPaymentMethod.php
+++ b/Model/Resolver/OrderPaymentMethod.php
@@ -9,6 +9,7 @@ use Magento\Framework\GraphQl\Query\Resolver\ContextInterface;
 use Magento\Framework\GraphQl\Query\ResolverInterface;
 use Magento\Framework\GraphQl\Schema\Type\ResolveInfo;
 use Tapbuy\RedirectTracking\Api\Authorization\TokenAuthorizationInterface;
+use Tapbuy\RedirectTracking\Api\ConfigInterface;
 use Magento\Sales\Model\Order\Payment;
 
 class OrderPaymentMethod implements ResolverInterface
@@ -24,12 +25,20 @@ class OrderPaymentMethod implements ResolverInterface
     private $tokenAuthorization;
 
     /**
+     * @var ConfigInterface
+     */
+    private $config;
+
+    /**
      * @param TokenAuthorizationInterface $tokenAuthorization
+     * @param ConfigInterface $config
      */
     public function __construct(
-        TokenAuthorizationInterface $tokenAuthorization
+        TokenAuthorizationInterface $tokenAuthorization,
+        ConfigInterface $config
     ) {
         $this->tokenAuthorization = $tokenAuthorization;
+        $this->config = $config;
     }
 
     /**
@@ -50,6 +59,10 @@ class OrderPaymentMethod implements ResolverInterface
         ?array $value = null,
         ?array $args = null
     ) {
+        if (!$this->config->isEnabled()) {
+            return null;
+        }
+
         $this->tokenAuthorization->authorize(self::ACL_RESOURCE);
 
         if (!isset($value['model'])) {

--- a/Model/Resolver/Product/ParentSku.php
+++ b/Model/Resolver/Product/ParentSku.php
@@ -10,6 +10,7 @@ use Magento\Framework\Exception\NoSuchEntityException;
 use Magento\Framework\GraphQl\Config\Element\Field;
 use Magento\Framework\GraphQl\Query\ResolverInterface;
 use Magento\Framework\GraphQl\Schema\Type\ResolveInfo;
+use Tapbuy\RedirectTracking\Api\ConfigInterface;
 
 /**
  * Resolver for parent_sku field on ProductInterface.
@@ -30,15 +31,23 @@ class ParentSku implements ResolverInterface
     private ProductRepositoryInterface $productRepository;
 
     /**
+     * @var ConfigInterface
+     */
+    private ConfigInterface $config;
+
+    /**
      * @param ConfigurableType $configurableType
      * @param ProductRepositoryInterface $productRepository
+     * @param ConfigInterface $config
      */
     public function __construct(
         ConfigurableType $configurableType,
-        ProductRepositoryInterface $productRepository
+        ProductRepositoryInterface $productRepository,
+        ConfigInterface $config
     ) {
         $this->configurableType = $configurableType;
         $this->productRepository = $productRepository;
+        $this->config = $config;
     }
 
     /**
@@ -58,6 +67,10 @@ class ParentSku implements ResolverInterface
         ?array $value = null,
         ?array $args = null
     ): ?string {
+        if (!$this->config->isEnabled()) {
+            return null;
+        }
+
         if (!isset($value['model'])) {
             return null;
         }

--- a/Model/Resolver/UnlockCart.php
+++ b/Model/Resolver/UnlockCart.php
@@ -14,6 +14,7 @@ use Magento\Sales\Model\ResourceModel\Order\CollectionFactory as OrderCollection
 use Magento\Sales\Model\Order;
 use Tapbuy\RedirectTracking\Api\Authorization\TokenAuthorizationInterface;
 use Tapbuy\RedirectTracking\Api\Cart\CartResolverInterface;
+use Tapbuy\RedirectTracking\Api\ConfigInterface;
 use Tapbuy\RedirectTracking\Api\LoggerInterface;
 
 class UnlockCart implements ResolverInterface
@@ -44,6 +45,11 @@ class UnlockCart implements ResolverInterface
     private $cartResolver;
 
     /**
+     * @var ConfigInterface
+     */
+    private $config;
+
+    /**
      * @var LoggerInterface
      */
     private $logger;
@@ -53,6 +59,7 @@ class UnlockCart implements ResolverInterface
      * @param OrderCollectionFactory $orderCollectionFactory
      * @param CartRepositoryInterface $cartRepository
      * @param CartResolverInterface $cartResolver
+     * @param ConfigInterface $config
      * @param LoggerInterface $logger
      */
     public function __construct(
@@ -60,12 +67,14 @@ class UnlockCart implements ResolverInterface
         OrderCollectionFactory $orderCollectionFactory,
         CartRepositoryInterface $cartRepository,
         CartResolverInterface $cartResolver,
+        ConfigInterface $config,
         LoggerInterface $logger
     ) {
         $this->tokenAuthorization = $tokenAuthorization;
         $this->orderCollectionFactory = $orderCollectionFactory;
         $this->cartRepository = $cartRepository;
         $this->cartResolver = $cartResolver;
+        $this->config = $config;
         $this->logger = $logger;
     }
 
@@ -87,6 +96,10 @@ class UnlockCart implements ResolverInterface
         ?array $value = null,
         ?array $args = null
     ) {
+        if (!$this->config->isEnabled()) {
+            throw new GraphQlInputException(__('Tapbuy is disabled.'));
+        }
+
         $this->tokenAuthorization->authorize(self::ACL_RESOURCE);
 
         if (empty($args['cart_id'])) {


### PR DESCRIPTION
This pull request adds a new configuration check to multiple GraphQL resolver classes to ensure that Tapbuy-related operations are only performed when Tapbuy is enabled. The change introduces a dependency on `ConfigInterface` in each resolver, injects it via the constructor, and adds logic to short-circuit or throw exceptions when Tapbuy is disabled. This improves the module's robustness and prevents unauthorized or unnecessary operations when Tapbuy is turned off.

**Configuration Enforcement in Resolvers**

* Injected `ConfigInterface` into constructors for all Tapbuy-related resolver classes (`Customer`, `CustomerSearch`, `DeactivateCart`, `GetOrder`, `GetOrderItems`, `ModulesVersions`, `OrderAddress`, `OrderAssignCustomer`, `OrderPaymentMethod`) to enable configuration-based control. [[1]](diffhunk://#diff-925451851b60ade7bfb4f947e0ea9b0aff9c3de3e96b41b6258ae97eb2f77e9bR26-R40) [[2]](diffhunk://#diff-6a2ac6e45603682cbed7d6b88d95c75ec63bdcb716a8731bcdd28c4bd33790fbR54-R59) [[3]](diffhunk://#diff-4209a602de23724a1b9bc8cb820f08b4fa741f2b1b93f3a3243505f818a14051R54-R67) [[4]](diffhunk://#diff-1f688f23ef81fb6bdec3066dc420fb0cf410f5e5481e5e69a99af347a5a9807dR51-R62) [[5]](diffhunk://#diff-ed8e05b97c9d2c74ce0f3295e11710624187e6935f90731ed0c0634cc8fe7b74R56-R67) [[6]](diffhunk://#diff-dc67624c372e359705498116b047c984cbec8d85e80a469d98f9f90644bccb34R78-R86) [[7]](diffhunk://#diff-8ee4b7d2ae307c255ed83c34611fc75abd17e999c6a67beb19ff4bd29aa499f9R26-R40) [[8]](diffhunk://#diff-9e88fcc9ed181eb71c874e6cb155c21edc52cf4327c99ade9b5bb1256f537635R65-R80)
* Added checks in each resolver's `resolve` method to return `null`, an empty array, or throw a `GraphQlInputException` when `ConfigInterface::isEnabled()` is `false`, effectively disabling Tapbuy GraphQL endpoints if the module is turned off. [[1]](diffhunk://#diff-925451851b60ade7bfb4f947e0ea9b0aff9c3de3e96b41b6258ae97eb2f77e9bR64-R67) [[2]](diffhunk://#diff-6a2ac6e45603682cbed7d6b88d95c75ec63bdcb716a8731bcdd28c4bd33790fbR84-R87) [[3]](diffhunk://#diff-4209a602de23724a1b9bc8cb820f08b4fa741f2b1b93f3a3243505f818a14051R89-R92) [[4]](diffhunk://#diff-1f688f23ef81fb6bdec3066dc420fb0cf410f5e5481e5e69a99af347a5a9807dR87-R90) [[5]](diffhunk://#diff-ed8e05b97c9d2c74ce0f3295e11710624187e6935f90731ed0c0634cc8fe7b74R84-R87) [[6]](diffhunk://#diff-dc67624c372e359705498116b047c984cbec8d85e80a469d98f9f90644bccb34R114-R118) [[7]](diffhunk://#diff-8ee4b7d2ae307c255ed83c34611fc75abd17e999c6a67beb19ff4bd29aa499f9R60-R63) [[8]](diffhunk://#diff-9e88fcc9ed181eb71c874e6cb155c21edc52cf4327c99ade9b5bb1256f537635R102-R105)
* Updated `ModulesVersions` resolver to report Tapbuy as disabled in its output when the configuration is off, improving visibility for clients querying module versions.

**Dependency Injection Updates**

* Modified constructor signatures and private member declarations to include `ConfigInterface` in all affected resolver classes, ensuring consistent dependency management. [[1]](diffhunk://#diff-925451851b60ade7bfb4f947e0ea9b0aff9c3de3e96b41b6258ae97eb2f77e9bR26-R40) [[2]](diffhunk://#diff-6a2ac6e45603682cbed7d6b88d95c75ec63bdcb716a8731bcdd28c4bd33790fbR40-R44) [[3]](diffhunk://#diff-4209a602de23724a1b9bc8cb820f08b4fa741f2b1b93f3a3243505f818a14051R40-R44) [[4]](diffhunk://#diff-1f688f23ef81fb6bdec3066dc420fb0cf410f5e5481e5e69a99af347a5a9807dR31-R39) [[5]](diffhunk://#diff-ed8e05b97c9d2c74ce0f3295e11710624187e6935f90731ed0c0634cc8fe7b74R37-R41) [[6]](diffhunk://#diff-dc67624c372e359705498116b047c984cbec8d85e80a469d98f9f90644bccb34R33-R37) [[7]](diffhunk://#diff-8ee4b7d2ae307c255ed83c34611fc75abd17e999c6a67beb19ff4bd29aa499f9R26-R40) [[8]](diffhunk://#diff-9e88fcc9ed181eb71c874e6cb155c21edc52cf4327c99ade9b5bb1256f537635R34-R38)

**GraphQL Exception Handling**

* Standardized error handling by throwing `GraphQlInputException` with a clear message ("Tapbuy is disabled.") in resolvers where an operation should not proceed if Tapbuy is disabled, providing better feedback for API consumers. [[1]](diffhunk://#diff-6a2ac6e45603682cbed7d6b88d95c75ec63bdcb716a8731bcdd28c4bd33790fbR84-R87) [[2]](diffhunk://#diff-4209a602de23724a1b9bc8cb820f08b4fa741f2b1b93f3a3243505f818a14051R89-R92) [[3]](diffhunk://#diff-1f688f23ef81fb6bdec3066dc420fb0cf410f5e5481e5e69a99af347a5a9807dR87-R90) [[4]](diffhunk://#diff-9e88fcc9ed181eb71c874e6cb155c21edc52cf4327c99ade9b5bb1256f537635R102-R105)

These changes collectively ensure that Tapbuy GraphQL endpoints are only accessible when the module is enabled, with clear error reporting and consistent dependency management across all resolvers.