### PR TITLE
PDT-468 Use resolveAndLoadQuote

### DIFF
--- a/Plugin/SetPaymentMethodOnCartPlugin.php
+++ b/Plugin/SetPaymentMethodOnCartPlugin.php
@@ -118,8 +118,7 @@ class SetPaymentMethodOnCartPlugin
      */
     private function setTapbuyAdditionalInformation(string $cartId, array $additionalInfo): void
     {
-        $quoteId = $this->cartResolver->resolveCartId($cartId);
-        $quote = $this->cartRepository->get($quoteId);
+        $quote = $this->cartResolver->resolveAndLoadQuote($cartId);
 
         $payment = $quote->getPayment();
 


### PR DESCRIPTION
This pull request makes a small change to the way the quote object is retrieved in the `setTapbuyAdditionalInformation` method. Instead of separately resolving the cart ID and then loading the quote, it now uses a single method to both resolve and load the quote object. This simplifies the code and may improve reliability.

* Simplified quote retrieval in `setTapbuyAdditionalInformation` by replacing separate cart ID resolution and quote loading with a single call to `resolveAndLoadQuote`.