### PR TITLE
MSK-198 Fix order cancel in unlock cart

### DIFF
--- a/Model/Resolver/UnlockCart.php
+++ b/Model/Resolver/UnlockCart.php
@@ -143,10 +143,8 @@ class UnlockCart implements ResolverInterface
             // Definition of the unlock reason
             $msgTxt = "Tapbuy Unlock: ";
             if ($unlockReason === 'cancel') {
-                $configDataKey = "order_status_payment_canceled";
                 $msgTxt .= "payment canceled";
             } else {
-                $configDataKey = "order_status_payment_refused";
                 $msgTxt .= "payment refused";
             }
 
@@ -154,29 +152,40 @@ class UnlockCart implements ResolverInterface
             $message = $order->addStatusHistoryComment($msgTxt);
             $message->setIsCustomerNotified(null);
 
-            try {
-                $paymentMethodInstance = $order->getPayment()->getMethodInstance();
-                $orderStatus = $paymentMethodInstance->getConfigData($configDataKey);
-            } catch (\Exception $e) {
+            // Cancel the order (release stock, cancel items, etc.)
+            // cancel() and registerCancellation() set state + status via getStateDefaultStatus()
+            if ($order->canCancel()) {
+                $order->cancel();
+            } elseif ($order->isPaymentReview() || $order->isFraudDetected()) {
+                // payment_review/fraud orders can't use cancel() — use registerCancellation() directly
+                try {
+                    $order->getPayment()->cancel();
+                } catch (\Exception $e) {
+                    $this->logger->warning(
+                        'Checkout-GraphQL: Failed to cancel payment for payment_review order',
+                        [
+                            'order_id' => $order->getIncrementId(),
+                            'error' => $e->getMessage(),
+                        ]
+                    );
+                }
+                $order->registerCancellation($msgTxt);
+            } else {
                 $this->logger->warning(
-                    'Checkout-GraphQL: Failed to get order status from payment method, using canceled',
+                    'Checkout-GraphQL: Order could not be canceled during unlock',
                     [
                         'order_id' => $order->getIncrementId(),
-                        'config_key' => $configDataKey,
-                        'error' => $e->getMessage(),
+                        'state' => $order->getState(),
+                        'status' => $order->getStatus(),
                     ]
                 );
-                $orderStatus = 'canceled';
             }
 
-            // Ensure the order is canceled, release stock, etc.
-            $order->cancel();
-            // Set the status and save the order
-            $order->setStatus($orderStatus)->save();
+            $order->save();
 
             $this->logger->debug('Checkout-GraphQL: Updated order status during unlock', [
                 'order_id' => $order->getIncrementId(),
-                'new_status' => $orderStatus,
+                'new_status' => $order->getStatus(),
                 'unlock_reason' => $unlockReason,
             ]);
         }

--- a/Model/Resolver/UnlockCart.php
+++ b/Model/Resolver/UnlockCart.php
@@ -148,13 +148,11 @@ class UnlockCart implements ResolverInterface
                 $msgTxt .= "payment refused";
             }
 
-            // Set message to order
-            $message = $order->addStatusHistoryComment($msgTxt);
-            $message->setIsCustomerNotified(null);
-
             // Cancel the order (release stock, cancel items, etc.)
             // cancel() and registerCancellation() set state + status via getStateDefaultStatus()
             if ($order->canCancel()) {
+                $order->addStatusHistoryComment($msgTxt)
+                    ->setIsCustomerNotified(null);
                 $order->cancel();
             } elseif ($order->isPaymentReview() || $order->isFraudDetected()) {
                 // payment_review/fraud orders can't use cancel() — use registerCancellation() directly
@@ -162,15 +160,21 @@ class UnlockCart implements ResolverInterface
                     $order->getPayment()->cancel();
                 } catch (\Exception $e) {
                     $this->logger->warning(
-                        'Checkout-GraphQL: Failed to cancel payment for payment_review order',
+                        'Checkout-GraphQL: Failed to cancel payment during unlock',
                         [
                             'order_id' => $order->getIncrementId(),
+                            'state' => $order->getState(),
+                            'status' => $order->getStatus(),
                             'error' => $e->getMessage(),
                         ]
                     );
                 }
+                // registerCancellation() adds its own status history comment
                 $order->registerCancellation($msgTxt);
             } else {
+                $order->addStatusHistoryComment(
+                    'Tapbuy Unlock: cancellation attempted but not possible (state: ' . $order->getState() . ')'
+                )->setIsCustomerNotified(null);
                 $this->logger->warning(
                     'Checkout-GraphQL: Order could not be canceled during unlock',
                     [


### PR DESCRIPTION
This pull request improves the handling of order cancellation logic in the `updateOrderStatus` function of `UnlockCart.php`, making it more robust and accurate for different order states. The main changes focus on properly canceling orders based on their state, ensuring stock is released, and logging issues when cancellation is not possible.

Order cancellation logic improvements:

* Refactored the order cancellation flow to use `cancel()` for normal orders, and `registerCancellation()` for orders in `payment_review` or `fraud` states, ensuring the correct state and status are set and stock is released.
* Added warnings and detailed logging when an order cannot be canceled or when cancellation fails, improving visibility into problematic cases.

Other adjustments:

* Removed reliance on payment method configuration for determining canceled status, simplifying the status assignment.
* Updated debug logging to reflect the actual new status of the order after cancellation.