### PR TITLE
PDT-480 Drop php ^7.4 requirement

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
         "OSL-3.0"
     ],
     "require": {
-        "php": "^7.4 || ^8.1",
+        "php": "^8.1",
         "magento/framework": "^103.0",
         "magento/module-graph-ql": "^100.4",
         "magento/module-quote": "^101.2",


### PR DESCRIPTION
This pull request updates the PHP version requirement in the `composer.json` file to improve compatibility and security.

Dependency requirements:

* Updated the PHP version requirement in `composer.json` from `^7.4 || ^8.1` to `^8.1`, removing support for PHP 7.4 and enforcing PHP 8.1 or higher.