### PR TITLE
PDT-480 Add typing

### DIFF
--- a/Model/OrderDataFormatter.php
+++ b/Model/OrderDataFormatter.php
@@ -5,22 +5,18 @@ declare(strict_types=1);
 namespace Tapbuy\CheckoutGraphql\Model;
 
 use Magento\Sales\Api\Data\OrderInterface;
+use Magento\Sales\Api\Data\ShippingAssignmentInterface;
+use Magento\Sales\Api\Data\ShippingInterface;
 use Magento\SalesGraphQl\Model\Formatter\Order as OrderFormatter;
 use Tapbuy\CheckoutGraphql\Api\OrderDataFormatterInterface;
 
 class OrderDataFormatter implements OrderDataFormatterInterface
 {
     /**
-     * @var OrderFormatter
-     */
-    private $orderFormatter;
-
-    /**
      * @param OrderFormatter $orderFormatter
      */
-    public function __construct(OrderFormatter $orderFormatter)
+    public function __construct(private readonly OrderFormatter $orderFormatter)
     {
-        $this->orderFormatter = $orderFormatter;
     }
 
     /**
@@ -138,10 +134,10 @@ class OrderDataFormatter implements OrderDataFormatterInterface
     /**
      * Extract shipping items from a shipping assignment.
      *
-     * @param \Magento\Sales\Api\Data\ShippingAssignmentInterface $assignment
+     * @param ShippingAssignmentInterface $assignment
      * @return array
      */
-    private function extractShippingItems($assignment): array
+    private function extractShippingItems(ShippingAssignmentInterface $assignment): array
     {
         $items = [];
         foreach ($assignment->getItems() as $item) {
@@ -157,10 +153,10 @@ class OrderDataFormatter implements OrderDataFormatterInterface
     /**
      * Extract and format shipping address from shipping object.
      *
-     * @param \Magento\Sales\Api\Data\ShippingInterface|null $shipping
+     * @param ShippingInterface|null $shipping
      * @return array|null
      */
-    private function extractShippingAddress($shipping): ?array
+    private function extractShippingAddress(?ShippingInterface $shipping): ?array
     {
         if (!$shipping || !$shipping->getAddress()) {
             return null;

--- a/Model/Resolver/Customer.php
+++ b/Model/Resolver/Customer.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Tapbuy\CheckoutGraphql\Model\Resolver;
 
+use Magento\Customer\Api\Data\CustomerInterface;
 use Magento\Framework\GraphQl\Config\Element\Field;
 use Magento\Framework\GraphQl\Query\Resolver\ContextInterface;
 use Magento\Framework\GraphQl\Query\ResolverInterface;
@@ -19,25 +20,13 @@ class Customer implements ResolverInterface
     private const ACL_RESOURCE = TokenAuthorizationInterface::TAPBUY_CUSTOMER_VIEW;
 
     /**
-     * @var TokenAuthorizationInterface
-     */
-    private $tokenAuthorization;
-
-    /**
-     * @var ConfigInterface
-     */
-    private $config;
-
-    /**
      * @param TokenAuthorizationInterface $tokenAuthorization
      * @param ConfigInterface $config
      */
     public function __construct(
-        TokenAuthorizationInterface $tokenAuthorization,
-        ConfigInterface $config
+        private readonly TokenAuthorizationInterface $tokenAuthorization,
+        private readonly ConfigInterface $config
     ) {
-        $this->tokenAuthorization = $tokenAuthorization;
-        $this->config = $config;
     }
 
     /**
@@ -88,10 +77,10 @@ class Customer implements ResolverInterface
     /**
      * Get customer ID
      *
-     * @param \Magento\Customer\Api\Data\CustomerInterface $customer
+     * @param CustomerInterface $customer
      * @return int
      */
-    private function getCustomerId($customer)
+    private function getCustomerId(CustomerInterface $customer): int
     {
         return $customer->getId();
     }

--- a/Model/Resolver/CustomerSearch.php
+++ b/Model/Resolver/CustomerSearch.php
@@ -23,41 +23,17 @@ class CustomerSearch implements ResolverInterface
     private const ACL_RESOURCE = TokenAuthorizationInterface::TAPBUY_CUSTOMER_SEARCH;
 
     /**
-     * @var CustomerRepositoryInterface
-     */
-    private $customerRepository;
-
-    /**
-     * @var ExtractCustomerData
-     */
-    private $extractCustomerData;
-
-    /**
-     * @var TokenAuthorizationInterface
-     */
-    private $tokenAuthorization;
-
-    /**
-     * @var ConfigInterface
-     */
-    private $config;
-
-    /**
      * @param CustomerRepositoryInterface $customerRepository
      * @param ExtractCustomerData $extractCustomerData
      * @param TokenAuthorizationInterface $tokenAuthorization
      * @param ConfigInterface $config
      */
     public function __construct(
-        CustomerRepositoryInterface $customerRepository,
-        ExtractCustomerData $extractCustomerData,
-        TokenAuthorizationInterface $tokenAuthorization,
-        ConfigInterface $config
+        private readonly CustomerRepositoryInterface $customerRepository,
+        private readonly ExtractCustomerData $extractCustomerData,
+        private readonly TokenAuthorizationInterface $tokenAuthorization,
+        private readonly ConfigInterface $config
     ) {
-        $this->customerRepository = $customerRepository;
-        $this->extractCustomerData = $extractCustomerData;
-        $this->tokenAuthorization = $tokenAuthorization;
-        $this->config = $config;
     }
 
     /**

--- a/Model/Resolver/DeactivateCart.php
+++ b/Model/Resolver/DeactivateCart.php
@@ -26,31 +26,6 @@ class DeactivateCart implements ResolverInterface
     private const ACL_RESOURCE = TokenAuthorizationInterface::TAPBUY_CART_DEACTIVATE;
 
     /**
-     * @var TokenAuthorizationInterface
-     */
-    private $tokenAuthorization;
-
-    /**
-     * @var CartRepositoryInterface
-     */
-    private $cartRepository;
-
-    /**
-     * @var CartResolverInterface
-     */
-    private $cartResolver;
-
-    /**
-     * @var ConfigInterface
-     */
-    private $config;
-
-    /**
-     * @var LoggerInterface
-     */
-    private $logger;
-
-    /**
      * @param TokenAuthorizationInterface $tokenAuthorization
      * @param CartRepositoryInterface $cartRepository
      * @param CartResolverInterface $cartResolver
@@ -58,17 +33,12 @@ class DeactivateCart implements ResolverInterface
      * @param LoggerInterface $logger
      */
     public function __construct(
-        TokenAuthorizationInterface $tokenAuthorization,
-        CartRepositoryInterface $cartRepository,
-        CartResolverInterface $cartResolver,
-        ConfigInterface $config,
-        LoggerInterface $logger
+        private readonly TokenAuthorizationInterface $tokenAuthorization,
+        private readonly CartRepositoryInterface $cartRepository,
+        private readonly CartResolverInterface $cartResolver,
+        private readonly ConfigInterface $config,
+        private readonly LoggerInterface $logger
     ) {
-        $this->tokenAuthorization = $tokenAuthorization;
-        $this->cartRepository = $cartRepository;
-        $this->cartResolver = $cartResolver;
-        $this->config = $config;
-        $this->logger = $logger;
     }
 
     /**

--- a/Model/Resolver/GetOrder.php
+++ b/Model/Resolver/GetOrder.php
@@ -24,41 +24,17 @@ class GetOrder implements ResolverInterface
     private const ACL_RESOURCE = TokenAuthorizationInterface::TAPBUY_ORDER_VIEW;
 
     /**
-     * @var TokenAuthorizationInterface
-     */
-    private $tokenAuthorization;
-
-    /**
-     * @var ConfigInterface
-     */
-    private $config;
-
-    /**
-     * @var OrderDataFormatterInterface
-     */
-    private $orderFormatter;
-
-    /**
-     * @var OrderLocatorInterface
-     */
-    private $orderLocator;
-
-    /**
      * @param TokenAuthorizationInterface $tokenAuthorization
      * @param OrderDataFormatterInterface $orderFormatter
      * @param OrderLocatorInterface $orderLocator
      * @param ConfigInterface $config
      */
     public function __construct(
-        TokenAuthorizationInterface $tokenAuthorization,
-        OrderDataFormatterInterface $orderFormatter,
-        OrderLocatorInterface $orderLocator,
-        ConfigInterface $config
+        private readonly TokenAuthorizationInterface $tokenAuthorization,
+        private readonly OrderDataFormatterInterface $orderFormatter,
+        private readonly OrderLocatorInterface $orderLocator,
+        private readonly ConfigInterface $config
     ) {
-        $this->tokenAuthorization = $tokenAuthorization;
-        $this->orderFormatter = $orderFormatter;
-        $this->orderLocator = $orderLocator;
-        $this->config = $config;
     }
 
     /**

--- a/Model/Resolver/GetOrderItems.php
+++ b/Model/Resolver/GetOrderItems.php
@@ -30,41 +30,17 @@ class GetOrderItems implements ResolverInterface
     private const ACL_RESOURCE = TokenAuthorizationInterface::TAPBUY_ORDER_VIEW;
 
     /**
-     * @var TokenAuthorizationInterface
-     */
-    private $tokenAuthorization;
-
-    /**
-     * @var ConfigInterface
-     */
-    private $config;
-
-    /**
-     * @var ValueFactory
-     */
-    private $valueFactory;
-
-    /**
-     * @var OrderItemProvider
-     */
-    private $orderItemProvider;
-
-    /**
      * @param TokenAuthorizationInterface $tokenAuthorization
      * @param ValueFactory $valueFactory
      * @param OrderItemProvider $orderItemProvider
      * @param ConfigInterface $config
      */
     public function __construct(
-        TokenAuthorizationInterface $tokenAuthorization,
-        ValueFactory $valueFactory,
-        OrderItemProvider $orderItemProvider,
-        ConfigInterface $config
+        private readonly TokenAuthorizationInterface $tokenAuthorization,
+        private readonly ValueFactory $valueFactory,
+        private readonly OrderItemProvider $orderItemProvider,
+        private readonly ConfigInterface $config
     ) {
-        $this->tokenAuthorization = $tokenAuthorization;
-        $this->valueFactory = $valueFactory;
-        $this->orderItemProvider = $orderItemProvider;
-        $this->config = $config;
     }
 
     /**
@@ -79,7 +55,7 @@ class GetOrderItems implements ResolverInterface
      * @param array|null $args The arguments provided in the GraphQL query.
      * @return mixed The resolved data for the order items.
      */
-    public function resolve(Field $field, $context, ResolveInfo $info, array $value = null, array $args = null)
+    public function resolve(Field $field, $context, ResolveInfo $info, ?array $value = null, ?array $args = null)
     {
         if (!$this->config->isEnabled()) {
             return [];

--- a/Model/Resolver/ModulesVersions.php
+++ b/Model/Resolver/ModulesVersions.php
@@ -24,41 +24,6 @@ class ModulesVersions implements ResolverInterface
     private const ACL_RESOURCE = TokenAuthorizationInterface::TAPBUY_MODULES_VERSIONS;
 
     /**
-     * @var TokenAuthorizationInterface
-     */
-    private $tokenAuthorization;
-
-    /**
-     * @var ConfigInterface
-     */
-    private $config;
-
-    /**
-     * @var ComponentRegistrar
-     */
-    private $componentRegistrar;
-
-    /**
-     * @var File
-     */
-    private $file;
-
-    /**
-     * @var Json
-     */
-    private $json;
-
-    /**
-     * @var ModuleManager
-     */
-    private $moduleManager;
-
-    /**
-     * @var LoggerInterface
-     */
-    private $logger;
-
-    /**
      * @param TokenAuthorizationInterface $tokenAuthorization
      * @param ComponentRegistrar $componentRegistrar
      * @param File $file
@@ -68,21 +33,14 @@ class ModulesVersions implements ResolverInterface
      * @param LoggerInterface $logger
      */
     public function __construct(
-        TokenAuthorizationInterface $tokenAuthorization,
-        ComponentRegistrar $componentRegistrar,
-        File $file,
-        Json $json,
-        ModuleManager $moduleManager,
-        ConfigInterface $config,
-        LoggerInterface $logger
+        private readonly TokenAuthorizationInterface $tokenAuthorization,
+        private readonly ComponentRegistrar $componentRegistrar,
+        private readonly File $file,
+        private readonly Json $json,
+        private readonly ModuleManager $moduleManager,
+        private readonly ConfigInterface $config,
+        private readonly LoggerInterface $logger
     ) {
-        $this->tokenAuthorization = $tokenAuthorization;
-        $this->componentRegistrar = $componentRegistrar;
-        $this->file = $file;
-        $this->json = $json;
-        $this->moduleManager = $moduleManager;
-        $this->config = $config;
-        $this->logger = $logger;
     }
 
     /**

--- a/Model/Resolver/OrderAddress.php
+++ b/Model/Resolver/OrderAddress.php
@@ -19,25 +19,13 @@ class OrderAddress implements ResolverInterface
     private const ACL_RESOURCE = TokenAuthorizationInterface::TAPBUY_ORDER_VIEW;
 
     /**
-     * @var TokenAuthorizationInterface
-     */
-    private $tokenAuthorization;
-
-    /**
-     * @var ConfigInterface
-     */
-    private $config;
-
-    /**
      * @param TokenAuthorizationInterface $tokenAuthorization
      * @param ConfigInterface $config
      */
     public function __construct(
-        TokenAuthorizationInterface $tokenAuthorization,
-        ConfigInterface $config
+        private readonly TokenAuthorizationInterface $tokenAuthorization,
+        private readonly ConfigInterface $config
     ) {
-        $this->tokenAuthorization = $tokenAuthorization;
-        $this->config = $config;
     }
 
     /**
@@ -84,7 +72,7 @@ class OrderAddress implements ResolverInterface
      * @param mixed $address
      * @return int|null
      */
-    private function getEntityId($address)
+    private function getEntityId(mixed $address): ?int
     {
         if (method_exists($address, 'getEntityId')) {
             return (int) $address->getEntityId();

--- a/Model/Resolver/OrderAssignCustomer.php
+++ b/Model/Resolver/OrderAssignCustomer.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Tapbuy\CheckoutGraphql\Model\Resolver;
 
 use Magento\Customer\Api\CustomerRepositoryInterface;
+use Magento\Customer\Api\Data\CustomerInterface;
 use Magento\Framework\Exception\LocalizedException;
 use Magento\Framework\Exception\NoSuchEntityException;
 use Magento\Framework\GraphQl\Config\Element\Field;
@@ -27,36 +28,6 @@ class OrderAssignCustomer implements ResolverInterface
     private const ACL_RESOURCE = TokenAuthorizationInterface::TAPBUY_ORDER_ASSIGN;
 
     /**
-     * @var TokenAuthorizationInterface
-     */
-    private $tokenAuthorization;
-
-    /**
-     * @var ConfigInterface
-     */
-    private $config;
-
-    /**
-     * @var OrderDataFormatterInterface
-     */
-    private $orderFormatter;
-
-    /**
-     * @var CustomerRepositoryInterface
-     */
-    private $customerRepository;
-
-    /**
-     * @var CustomerAssignment
-     */
-    private $customerAssignment;
-
-    /**
-     * @var OrderLocatorInterface
-     */
-    private $orderLocator;
-
-    /**
      * @param TokenAuthorizationInterface $tokenAuthorization
      * @param OrderDataFormatterInterface $orderFormatter
      * @param CustomerRepositoryInterface $customerRepository
@@ -65,19 +36,13 @@ class OrderAssignCustomer implements ResolverInterface
      * @param ConfigInterface $config
      */
     public function __construct(
-        TokenAuthorizationInterface $tokenAuthorization,
-        OrderDataFormatterInterface $orderFormatter,
-        CustomerRepositoryInterface $customerRepository,
-        CustomerAssignment $customerAssignment,
-        OrderLocatorInterface $orderLocator,
-        ConfigInterface $config
+        private readonly TokenAuthorizationInterface $tokenAuthorization,
+        private readonly OrderDataFormatterInterface $orderFormatter,
+        private readonly CustomerRepositoryInterface $customerRepository,
+        private readonly CustomerAssignment $customerAssignment,
+        private readonly OrderLocatorInterface $orderLocator,
+        private readonly ConfigInterface $config
     ) {
-        $this->tokenAuthorization = $tokenAuthorization;
-        $this->orderFormatter = $orderFormatter;
-        $this->customerRepository = $customerRepository;
-        $this->customerAssignment = $customerAssignment;
-        $this->orderLocator = $orderLocator;
-        $this->config = $config;
     }
 
     /**
@@ -173,7 +138,7 @@ class OrderAssignCustomer implements ResolverInterface
      * @return \Magento\Customer\Api\Data\CustomerInterface
      * @throws GraphQlNoSuchEntityException
      */
-    private function getCustomerById(int $customerId)
+    private function getCustomerById(int $customerId): CustomerInterface
     {
         try {
             return $this->customerRepository->getById($customerId);

--- a/Model/Resolver/OrderPaymentMethod.php
+++ b/Model/Resolver/OrderPaymentMethod.php
@@ -20,25 +20,13 @@ class OrderPaymentMethod implements ResolverInterface
     private const ACL_RESOURCE = TokenAuthorizationInterface::TAPBUY_ORDER_VIEW;
 
     /**
-     * @var TokenAuthorizationInterface
-     */
-    private $tokenAuthorization;
-
-    /**
-     * @var ConfigInterface
-     */
-    private $config;
-
-    /**
      * @param TokenAuthorizationInterface $tokenAuthorization
      * @param ConfigInterface $config
      */
     public function __construct(
-        TokenAuthorizationInterface $tokenAuthorization,
-        ConfigInterface $config
+        private readonly TokenAuthorizationInterface $tokenAuthorization,
+        private readonly ConfigInterface $config
     ) {
-        $this->tokenAuthorization = $tokenAuthorization;
-        $this->config = $config;
     }
 
     /**
@@ -50,7 +38,6 @@ class OrderPaymentMethod implements ResolverInterface
      * @param array|null $value The value resolved by the parent field, if any.
      * @param array|null $args The arguments provided in the GraphQL query.
      * @return mixed The resolved payment method data for the order.
-     * @throws LocalizedException If an error occurs during resolution.
      */
     public function resolve(
         Field $field,

--- a/Model/Resolver/Product/ParentSku.php
+++ b/Model/Resolver/Product/ParentSku.php
@@ -21,33 +21,15 @@ use Tapbuy\RedirectTracking\Api\ConfigInterface;
 class ParentSku implements ResolverInterface
 {
     /**
-     * @var ConfigurableType
-     */
-    private ConfigurableType $configurableType;
-
-    /**
-     * @var ProductRepositoryInterface
-     */
-    private ProductRepositoryInterface $productRepository;
-
-    /**
-     * @var ConfigInterface
-     */
-    private ConfigInterface $config;
-
-    /**
      * @param ConfigurableType $configurableType
      * @param ProductRepositoryInterface $productRepository
      * @param ConfigInterface $config
      */
     public function __construct(
-        ConfigurableType $configurableType,
-        ProductRepositoryInterface $productRepository,
-        ConfigInterface $config
+        private readonly ConfigurableType $configurableType,
+        private readonly ProductRepositoryInterface $productRepository,
+        private readonly ConfigInterface $config
     ) {
-        $this->configurableType = $configurableType;
-        $this->productRepository = $productRepository;
-        $this->config = $config;
     }
 
     /**

--- a/Model/Resolver/UnlockCart.php
+++ b/Model/Resolver/UnlockCart.php
@@ -28,36 +28,6 @@ class UnlockCart implements ResolverInterface
     private const ACL_RESOURCE = TokenAuthorizationInterface::TAPBUY_CART_UNLOCK;
 
     /**
-     * @var TokenAuthorizationInterface
-     */
-    private $tokenAuthorization;
-
-    /**
-     * @var OrderCollectionFactory
-     */
-    private $orderCollectionFactory;
-
-    /**
-     * @var CartRepositoryInterface
-     */
-    private $cartRepository;
-
-    /**
-     * @var CartResolverInterface
-     */
-    private $cartResolver;
-
-    /**
-     * @var ConfigInterface
-     */
-    private $config;
-
-    /**
-     * @var LoggerInterface
-     */
-    private $logger;
-
-    /**
      * @param TokenAuthorizationInterface $tokenAuthorization
      * @param OrderCollectionFactory $orderCollectionFactory
      * @param CartRepositoryInterface $cartRepository
@@ -66,19 +36,13 @@ class UnlockCart implements ResolverInterface
      * @param LoggerInterface $logger
      */
     public function __construct(
-        TokenAuthorizationInterface $tokenAuthorization,
-        OrderCollectionFactory $orderCollectionFactory,
-        CartRepositoryInterface $cartRepository,
-        CartResolverInterface $cartResolver,
-        ConfigInterface $config,
-        LoggerInterface $logger
+        private readonly TokenAuthorizationInterface $tokenAuthorization,
+        private readonly OrderCollectionFactory $orderCollectionFactory,
+        private readonly CartRepositoryInterface $cartRepository,
+        private readonly CartResolverInterface $cartResolver,
+        private readonly ConfigInterface $config,
+        private readonly LoggerInterface $logger
     ) {
-        $this->tokenAuthorization = $tokenAuthorization;
-        $this->orderCollectionFactory = $orderCollectionFactory;
-        $this->cartRepository = $cartRepository;
-        $this->cartResolver = $cartResolver;
-        $this->config = $config;
-        $this->logger = $logger;
     }
 
     /**

--- a/Plugin/SetPaymentMethodOnCartPlugin.php
+++ b/Plugin/SetPaymentMethodOnCartPlugin.php
@@ -84,8 +84,8 @@ class SetPaymentMethodOnCartPlugin
         Field $field,
         $context,
         ResolveInfo $info,
-        array $value = null,
-        array $args = null
+        ?array $value = null,
+        ?array $args = null
     ) {
         // Early return for non-Tapbuy requests to avoid unnecessary processing
         if (!$this->requestDetector->isTapbuyCall()) {


### PR DESCRIPTION
This pull request refactors several resolver and formatter classes to use PHP 8 constructor property promotion and strict type hinting. The changes streamline the codebase by removing redundant property declarations and assignments, making the code more concise and easier to maintain. Additionally, parameter and return type hints are improved for better type safety.

Key changes include:

### Refactoring to Constructor Property Promotion

* Updated constructors in resolver and formatter classes (such as `Customer`, `CustomerSearch`, `DeactivateCart`, `GetOrder`, `GetOrderItems`, `ModulesVersions`, `OrderAddress`, `OrderAssignCustomer`, `OrderPaymentMethod`, and `ParentSku`) to use constructor property promotion with `private readonly` properties, eliminating the need for separate property declarations and assignments. [[1]](diffhunk://#diff-23338816e403053c303e1544085f76e5a9049f64f4ddd18f2a1a0ed645da4f23R8-L23) [[2]](diffhunk://#diff-925451851b60ade7bfb4f947e0ea9b0aff9c3de3e96b41b6258ae97eb2f77e9bL21-L40) [[3]](diffhunk://#diff-6a2ac6e45603682cbed7d6b88d95c75ec63bdcb716a8731bcdd28c4bd33790fbL25-L60) [[4]](diffhunk://#diff-4209a602de23724a1b9bc8cb820f08b4fa741f2b1b93f3a3243505f818a14051L28-L52) [[5]](diffhunk://#diff-4209a602de23724a1b9bc8cb820f08b4fa741f2b1b93f3a3243505f818a14051L61-L71) [[6]](diffhunk://#diff-dc67624c372e359705498116b047c984cbec8d85e80a469d98f9f90644bccb34L26-L60) [[7]](diffhunk://#diff-dc67624c372e359705498116b047c984cbec8d85e80a469d98f9f90644bccb34L71-L85) [[8]](diffhunk://#diff-8ee4b7d2ae307c255ed83c34611fc75abd17e999c6a67beb19ff4bd29aa499f9L21-L40) [[9]](diffhunk://#diff-9e88fcc9ed181eb71c874e6cb155c21edc52cf4327c99ade9b5bb1256f537635L29-L58) [[10]](diffhunk://#diff-9e88fcc9ed181eb71c874e6cb155c21edc52cf4327c99ade9b5bb1256f537635L68-L80) [[11]](diffhunk://#diff-abb9e10273116484ac84de786224ed01d85fcf43d841b25461bcb729440459deL22-L41) [[12]](diffhunk://#diff-b5159c25caea2629c1a914387d5dd7979bb86d38d4376ff27be06fb6f63e0f9dL23-L50)

### Improved Type Hinting

* Added or improved parameter and return type hints for methods, such as using `CustomerInterface`, `ShippingAssignmentInterface`, `ShippingInterface`, and explicit scalar types (e.g., `int`, `?int`, `?array`) in method signatures for better type safety and clarity. [[1]](diffhunk://#diff-23338816e403053c303e1544085f76e5a9049f64f4ddd18f2a1a0ed645da4f23L141-R140) [[2]](diffhunk://#diff-23338816e403053c303e1544085f76e5a9049f64f4ddd18f2a1a0ed645da4f23L160-R159) [[3]](diffhunk://#diff-925451851b60ade7bfb4f947e0ea9b0aff9c3de3e96b41b6258ae97eb2f77e9bL91-R83) [[4]](diffhunk://#diff-8ee4b7d2ae307c255ed83c34611fc75abd17e999c6a67beb19ff4bd29aa499f9L87-R75) [[5]](diffhunk://#diff-9e88fcc9ed181eb71c874e6cb155c21edc52cf4327c99ade9b5bb1256f537635L176-R141) [[6]](diffhunk://#diff-ed8e05b97c9d2c74ce0f3295e11710624187e6935f90731ed0c0634cc8fe7b74L82-R58)

### Minor Cleanup

* Removed unnecessary docblocks and redundant comments, and made minor adjustments to method docblocks for clarity and accuracy.

These changes modernize the codebase, making it more maintainable and robust by leveraging newer PHP features and enforcing stricter typing.