### PR TITLE
PDT-480 Cli lint

### DIFF
--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -1,0 +1,62 @@
+name: Static Analysis
+
+on:
+  push:
+    branches:
+      - develop
+      - master
+      - 'release/**'
+      - 'hotfix/**'
+  pull_request:
+    branches:
+      - develop
+      - master
+
+jobs:
+  phpmd:
+    name: PHPMD
+    runs-on: ubuntu-latest
+    continue-on-error: true
+
+    steps:
+      - name: Checkout module
+        uses: actions/checkout@v4
+
+      - name: Setup PHP 8.3
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.3'
+          tools: composer:v2
+          coverage: none
+
+      - name: Install PHPMD
+        run: composer global require phpmd/phpmd --no-interaction
+
+      - name: Run PHPMD
+        run: phpmd . text cleancode,codesize,controversial,design,naming,unusedcode --exclude Test
+
+  phpcs:
+    name: PHPCS (Magento2)
+    runs-on: ubuntu-latest
+    continue-on-error: true
+
+    steps:
+      - name: Checkout module
+        uses: actions/checkout@v4
+
+      - name: Setup PHP 8.3
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.3'
+          tools: composer:v2
+          coverage: none
+
+      - name: Install PHPCS + Magento2 standard
+        run: |
+          composer global config allow-plugins.dealerdirect/phpcodesniffer-composer-installer true
+          composer global require squizlabs/php_codesniffer magento/magento-coding-standard --no-interaction
+
+      - name: Run PHPCS
+        run: |
+          set -o pipefail
+          phpcs -s --extensions=php . | grep -v -E "^DEPRECATED|sniff is listening for"

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -16,7 +16,6 @@ jobs:
   phpmd:
     name: PHPMD
     runs-on: ubuntu-latest
-    continue-on-error: true
 
     steps:
       - name: Checkout module
@@ -30,15 +29,14 @@ jobs:
           coverage: none
 
       - name: Install PHPMD
-        run: composer global require phpmd/phpmd --no-interaction
+        run: composer global require phpmd/phpmd:2.15.0 --no-interaction
 
       - name: Run PHPMD
-        run: phpmd . text cleancode,codesize,controversial,design,naming,unusedcode --exclude Test
+        run: phpmd . text phpmd.xml
 
   phpcs:
     name: PHPCS (Magento2)
     runs-on: ubuntu-latest
-    continue-on-error: true
 
     steps:
       - name: Checkout module
@@ -54,9 +52,9 @@ jobs:
       - name: Install PHPCS + Magento2 standard
         run: |
           composer global config allow-plugins.dealerdirect/phpcodesniffer-composer-installer true
-          composer global require squizlabs/php_codesniffer magento/magento-coding-standard --no-interaction
+          composer global require squizlabs/php_codesniffer:3.13.5 magento/magento-coding-standard:40 --no-interaction
 
       - name: Run PHPCS
         run: |
-          set -o pipefail
-          phpcs -s --extensions=php . | grep -v -E "^DEPRECATED|sniff is listening for"
+          phpcs -s --extensions=php . | { grep -v -E "^DEPRECATED|sniff is listening for" || true; }
+          exit ${PIPESTATUS[0]}

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,3 +28,12 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && rm -rf /var/lib/apt/lists/*
 
 COPY --from=composer:2 /usr/bin/composer /usr/bin/composer
+
+# Install global PHP code quality tools (used by `make phpmd`, `make phpcs`, `make lint`)
+ENV COMPOSER_HOME=/root/.composer
+RUN composer global config allow-plugins.dealerdirect/phpcodesniffer-composer-installer true \
+    && composer global require --no-interaction \
+        phpmd/phpmd \
+        squizlabs/php_codesniffer \
+        magento/magento-coding-standard
+ENV PATH="/root/.composer/vendor/bin:$PATH"

--- a/Dockerfile
+++ b/Dockerfile
@@ -29,11 +29,16 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 COPY --from=composer:2 /usr/bin/composer /usr/bin/composer
 
-# Install global PHP code quality tools (used by `make phpmd`, `make phpcs`, `make lint`)
+# Install global PHP code quality tools (used by `make phpmd`, `make phpcs`, `make lint`).
+# Versions are pinned to match .github/workflows/static-analysis.yml; override at build time with
+#   docker build --build-arg PHPMD_VERSION=x.y.z --build-arg PHPCS_VERSION=x.y.z ...
+ARG PHPMD_VERSION=2.15.0
+ARG PHPCS_VERSION=3.13.5
+ARG MAGENTO_CS_VERSION=40
 ENV COMPOSER_HOME=/root/.composer
 RUN composer global config allow-plugins.dealerdirect/phpcodesniffer-composer-installer true \
     && composer global require --no-interaction \
-        phpmd/phpmd \
-        squizlabs/php_codesniffer \
-        magento/magento-coding-standard
+        phpmd/phpmd:${PHPMD_VERSION} \
+        squizlabs/php_codesniffer:${PHPCS_VERSION} \
+        magento/magento-coding-standard:${MAGENTO_CS_VERSION}
 ENV PATH="/root/.composer/vendor/bin:$PATH"

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,13 @@
-.PHONY: test
+.PHONY: test phpmd phpcs lint
 
 test:
 	@bash ./run-tests.sh
+
+phpmd:
+	@bash ./run-lint.sh phpmd
+
+phpcs:
+	@bash ./run-lint.sh phpcs
+
+lint:
+	@bash ./run-lint.sh lint

--- a/Model/Resolver/ModulesVersions.php
+++ b/Model/Resolver/ModulesVersions.php
@@ -75,55 +75,61 @@ class ModulesVersions implements ResolverInterface
         $allModules = $this->componentRegistrar->getPaths(ComponentRegistrar::MODULE);
 
         foreach ($allModules as $moduleName => $modulePath) {
-            // Check if module is under Tapbuy namespace
-            if (strpos($moduleName, 'Tapbuy_') === 0) {
-                $composerJsonPath = $modulePath . '/composer.json';
-                $isEnabled = $this->moduleManager->isEnabled($moduleName);
+            // Skip non-Tapbuy modules
+            if (strpos($moduleName, 'Tapbuy_') !== 0) {
+                continue;
+            }
 
-                try {
-                    if ($this->file->isExists($composerJsonPath)) {
-                        $composerContent = $this->file->fileGetContents($composerJsonPath);
-                        $composerData = $this->json->unserialize($composerContent);
+            $composerJsonPath = $modulePath . '/composer.json';
+            $isEnabled = $this->moduleManager->isEnabled($moduleName);
 
-                        $tapbuyModules[] = [
-                            'name' => $composerData['name'] ?? $moduleName,
-                            'version' => $composerData['version'] ?? 'Unknown',
-                            'enabled' => $isEnabled
-                        ];
-                    } else {
-                        // If no composer.json, still add module with unknown version
-                        $tapbuyModules[] = [
-                            'name' => $moduleName,
-                            'version' => 'Unknown',
-                            'enabled' => $isEnabled
-                        ];
-                    }
-                } catch (\InvalidArgumentException $e) {
-                    $this->logger->logException(
-                        'Failed to parse composer.json for module (malformed JSON)',
-                        $e,
-                        ['module' => $moduleName, 'path' => $composerJsonPath]
-                    );
-                    $tapbuyModules[] = [
-                        'name' => $moduleName,
-                        'version' => 'Unknown',
-                        'enabled' => $isEnabled
-                    ];
-                } catch (\RuntimeException $e) {
-                    $this->logger->logException(
-                        'Failed to read composer.json for module (filesystem error)',
-                        $e,
-                        ['module' => $moduleName, 'path' => $composerJsonPath]
-                    );
-                    $tapbuyModules[] = [
-                        'name' => $moduleName,
-                        'version' => 'Unknown',
-                        'enabled' => $isEnabled
-                    ];
-                }
+            try {
+                $tapbuyModules[] = $this->resolveModuleVersionEntry($moduleName, $composerJsonPath, $isEnabled);
+            } catch (\InvalidArgumentException $e) {
+                $this->logger->logException(
+                    'Failed to parse composer.json for module (malformed JSON)',
+                    $e,
+                    ['module' => $moduleName, 'path' => $composerJsonPath]
+                );
+                $tapbuyModules[] = ['name' => $moduleName, 'version' => 'Unknown', 'enabled' => $isEnabled];
+            } catch (\RuntimeException $e) {
+                $this->logger->logException(
+                    'Failed to read composer.json for module (filesystem error)',
+                    $e,
+                    ['module' => $moduleName, 'path' => $composerJsonPath]
+                );
+                $tapbuyModules[] = ['name' => $moduleName, 'version' => 'Unknown', 'enabled' => $isEnabled];
             }
         }
 
         return $tapbuyModules;
+    }
+
+    /**
+     * Resolve the version entry for a single Tapbuy module.
+     *
+     * Reads the module's composer.json if it exists; otherwise returns an Unknown version entry.
+     *
+     * @param string $moduleName
+     * @param string $composerJsonPath
+     * @param bool $isEnabled
+     * @return array
+     * @throws \RuntimeException If the file cannot be read.
+     * @throws \InvalidArgumentException If the JSON is malformed.
+     */
+    private function resolveModuleVersionEntry(string $moduleName, string $composerJsonPath, bool $isEnabled): array
+    {
+        if (!$this->file->isExists($composerJsonPath)) {
+            return ['name' => $moduleName, 'version' => 'Unknown', 'enabled' => $isEnabled];
+        }
+
+        $composerContent = $this->file->fileGetContents($composerJsonPath);
+        $composerData = $this->json->unserialize($composerContent);
+
+        return [
+            'name' => $composerData['name'] ?? $moduleName,
+            'version' => $composerData['version'] ?? 'Unknown',
+            'enabled' => $isEnabled,
+        ];
     }
 }

--- a/Model/Resolver/OrderAssignCustomer.php
+++ b/Model/Resolver/OrderAssignCustomer.php
@@ -93,27 +93,15 @@ class OrderAssignCustomer implements ResolverInterface
         }
         $customer = $this->getCustomerById($customerId);
 
-        if (!$order->getCustomerIsGuest()) {
-            if ((int)$order->getCustomerId() === $customerId) {
-                return [
-                    'success' => true,
-                    'order' => $this->orderFormatter->format($order)
-                ];
-            }
-
-            throw new GraphQlInputException(__('Order is already assigned to a customer.'));
+        $alreadyAssigned = $this->resolveAlreadyAssigned($order, $customerId);
+        if ($alreadyAssigned !== null) {
+            return $alreadyAssigned;
         }
 
-        $orderEmail = trim((string)$order->getCustomerEmail());
-        $customerEmail = trim((string)$customer->getEmail());
-
-        if ($orderEmail === '' || $customerEmail === '') {
-            throw new GraphQlInputException(__('Order or customer email is missing.'));
-        }
-
-        if (strcasecmp($orderEmail, $customerEmail) !== 0) {
-            throw new GraphQlInputException(__('Order email does not match the customer email.'));
-        }
+        $this->assertEmailsCompatible(
+            trim((string)$order->getCustomerEmail()),
+            trim((string)$customer->getEmail())
+        );
 
         try {
             $this->customerAssignment->execute($order, $customer);
@@ -179,5 +167,52 @@ class OrderAssignCustomer implements ResolverInterface
         }
 
         return $normalizedType;
+    }
+
+    /**
+     * Check if the order is already assigned (non-guest) and return result or throw if conflict.
+     *
+     * Returns null when the order is a guest order and assignment can proceed.
+     * Returns the formatted order array when already assigned to the same customer (idempotent).
+     * Throws when the order is assigned to a different customer.
+     *
+     * @param mixed $order
+     * @param int $customerId
+     * @return array|null
+     * @throws GraphQlInputException
+     */
+    private function resolveAlreadyAssigned($order, int $customerId): ?array
+    {
+        if ($order->getCustomerIsGuest()) {
+            return null;
+        }
+
+        if ((int)$order->getCustomerId() === $customerId) {
+            return [
+                'success' => true,
+                'order' => $this->orderFormatter->format($order)
+            ];
+        }
+
+        throw new GraphQlInputException(__('Order is already assigned to a customer.'));
+    }
+
+    /**
+     * Assert that the order and customer emails are present and match (case-insensitive).
+     *
+     * @param string $orderEmail
+     * @param string $customerEmail
+     * @return void
+     * @throws GraphQlInputException
+     */
+    private function assertEmailsCompatible(string $orderEmail, string $customerEmail): void
+    {
+        if ($orderEmail === '' || $customerEmail === '') {
+            throw new GraphQlInputException(__('Order or customer email is missing.'));
+        }
+
+        if (strcasecmp($orderEmail, $customerEmail) !== 0) {
+            throw new GraphQlInputException(__('Order email does not match the customer email.'));
+        }
     }
 }

--- a/Model/Resolver/UnlockCart.php
+++ b/Model/Resolver/UnlockCart.php
@@ -107,60 +107,9 @@ class UnlockCart implements ResolverInterface
         $orders = $this->getActiveOrdersByQuoteId($quoteId);
 
         foreach ($orders as $order) {
-            // Definition of the unlock reason
-            $msgTxt = "Tapbuy Unlock: ";
-            if ($unlockReason === 'cancel') {
-                $msgTxt .= "payment canceled";
-            } else {
-                $msgTxt .= "payment refused";
-            }
+            $msgTxt = 'Tapbuy Unlock: ' . ($unlockReason === 'cancel' ? 'payment canceled' : 'payment refused');
 
-            // Cancel the order (release stock, cancel items, etc.)
-            // cancel() and registerCancellation() set state + status via getStateDefaultStatus()
-            if ($order->canCancel()) {
-                $order->addStatusHistoryComment($msgTxt)
-                    ->setIsCustomerNotified(null);
-                $order->cancel();
-            } elseif ($order->isPaymentReview() || $order->isFraudDetected()) {
-                // payment_review/fraud orders can't use cancel() — use registerCancellation() directly
-                try {
-                    $order->getPayment()->cancel();
-                } catch (LocalizedException $e) {
-                    $this->logger->warning(
-                        'Checkout-GraphQL: Failed to cancel payment during unlock (Magento exception)',
-                        [
-                            'order_id' => $order->getIncrementId(),
-                            'state' => $order->getState(),
-                            'status' => $order->getStatus(),
-                            'error' => $e->getMessage(),
-                        ]
-                    );
-                } catch (\RuntimeException $e) {
-                    $this->logger->warning(
-                        'Checkout-GraphQL: Failed to cancel payment during unlock (gateway exception)',
-                        [
-                            'order_id' => $order->getIncrementId(),
-                            'state' => $order->getState(),
-                            'status' => $order->getStatus(),
-                            'error' => $e->getMessage(),
-                        ]
-                    );
-                }
-                // registerCancellation() adds its own status history comment
-                $order->registerCancellation($msgTxt);
-            } else {
-                $order->addStatusHistoryComment(
-                    'Tapbuy Unlock: cancellation attempted but not possible (state: ' . $order->getState() . ')'
-                )->setIsCustomerNotified(null);
-                $this->logger->warning(
-                    'Checkout-GraphQL: Order could not be canceled during unlock',
-                    [
-                        'order_id' => $order->getIncrementId(),
-                        'state' => $order->getState(),
-                        'status' => $order->getStatus(),
-                    ]
-                );
-            }
+            $this->cancelOrder($order, $msgTxt);
 
             try {
                 $order->save();
@@ -177,6 +126,68 @@ class UnlockCart implements ResolverInterface
                 'unlock_reason' => $unlockReason,
             ]);
         }
+    }
+
+    /**
+     * Attempt to cancel a single order, choosing the appropriate cancellation path.
+     *
+     * Uses cancel() for regular orders, registerCancellation() for payment-review/fraud orders,
+     * and logs a warning when the order state does not allow cancellation at all.
+     *
+     * @param Order $order
+     * @param string $msgTxt Status history comment to attach.
+     * @return void
+     */
+    private function cancelOrder(Order $order, string $msgTxt): void
+    {
+        if ($order->canCancel()) {
+            // Standard cancellation: releases stock and transitions state via cancel()
+            $order->addStatusHistoryComment($msgTxt)->setIsCustomerNotified(null);
+            $order->cancel();
+            return;
+        }
+
+        if ($order->isPaymentReview() || $order->isFraudDetected()) {
+            // payment_review/fraud orders can't use cancel() — use registerCancellation() directly
+            try {
+                $order->getPayment()->cancel();
+            } catch (LocalizedException $e) {
+                $this->logger->warning(
+                    'Checkout-GraphQL: Failed to cancel payment during unlock (Magento exception)',
+                    [
+                        'order_id' => $order->getIncrementId(),
+                        'state' => $order->getState(),
+                        'status' => $order->getStatus(),
+                        'error' => $e->getMessage(),
+                    ]
+                );
+            } catch (\RuntimeException $e) {
+                $this->logger->warning(
+                    'Checkout-GraphQL: Failed to cancel payment during unlock (gateway exception)',
+                    [
+                        'order_id' => $order->getIncrementId(),
+                        'state' => $order->getState(),
+                        'status' => $order->getStatus(),
+                        'error' => $e->getMessage(),
+                    ]
+                );
+            }
+            // registerCancellation() adds its own status history comment
+            $order->registerCancellation($msgTxt);
+            return;
+        }
+
+        $order->addStatusHistoryComment(
+            'Tapbuy Unlock: cancellation attempted but not possible (state: ' . $order->getState() . ')'
+        )->setIsCustomerNotified(null);
+        $this->logger->warning(
+            'Checkout-GraphQL: Order could not be canceled during unlock',
+            [
+                'order_id' => $order->getIncrementId(),
+                'state' => $order->getState(),
+                'status' => $order->getStatus(),
+            ]
+        );
     }
 
     /**

--- a/README.md
+++ b/README.md
@@ -332,4 +332,23 @@ make test
 On the first run, the Docker image is built and Magento is installed into a named volume (`tapbuy-magento-2.4.7-p5-php83`). Subsequent runs reuse the cached volume and are fast.
 
 > Do not use `composer test` — it runs PHPUnit without the Magento bootstrap and will fail or produce misleading results.
+
+### Linting
+
+Linting runs PHPMD and PHPCS (Magento2 standard) inside the same Docker container as tests. Docker must be running.
+
+**Run both linters:**
+
+```bash
+make lint
+```
+
+**Run individually:**
+
+```bash
+make phpmd   # PHP Mess Detector
+make phpcs   # PHP CodeSniffer (Magento2 standard)
+```
+
+Both linters always run when using `make lint`; if either fails, the command exits with a non-zero code.
    - Check order visibility settings

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0"?>
+<ruleset name="Tapbuy">
+    <description>Magento2 coding standard — PHP files only, tests excluded.</description>
+
+    <!-- Exclude test directory -->
+    <exclude-pattern>*/Test/*</exclude-pattern>
+
+    <rule ref="Magento2">
+        <!-- Suppress the deprecated Squiz.CSS.NamedColours sniff (removed in PHPCS 4.0) -->
+        <exclude name="Squiz.CSS.NamedColours"/>
+    </rule>
+</ruleset>

--- a/phpmd.xml
+++ b/phpmd.xml
@@ -1,0 +1,81 @@
+<?xml version="1.0"?>
+<ruleset name="tapbuy-checkout-graphql"
+         xmlns="http://pmd.sf.net/ruleset/1.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://pmd.sf.net/ruleset/1.0.0 http://pmd.sf.net/ruleset_xml_schema.xsd"
+         xsi:noNamespaceSchemaLocation="http://pmd.sf.net/ruleset_xml_schema.xsd">
+
+    <description>PHPMD ruleset for Tapbuy Checkout GraphQL module</description>
+
+    <!-- Exclude test directory from analysis -->
+    <exclude-pattern>*/Test/*</exclude-pattern>
+
+    <!--
+        Clean code: suppress BooleanArgumentFlag.
+        setCookie/removeCookie use bool flags intentionally — they mirror PHP's
+        setcookie() API and Magento's own CookieMetadata pattern. Enforcing SRP
+        here would require a separate object per flag combination, which is
+        over-engineered for this context.
+    -->
+    <rule ref="rulesets/cleancode.xml">
+        <exclude name="BooleanArgumentFlag"/>
+    </rule>
+
+    <!--
+        Code size: all default rules. CouplingBetweenObjects lives in design.xml
+        (overridden below), not codesize.xml.
+    -->
+    <rule ref="rulesets/codesize.xml"/>
+
+    <!-- Controversial: all default rules -->
+    <rule ref="rulesets/controversial.xml"/>
+
+    <!-- Design: all default rules, with CouplingBetweenObjects threshold raised to 15.
+         Model/Service.php aggregates several Magento framework objects (Curl, Json,
+         Url, Request, etc.) that Magento DI injects as a single cohesive unit.
+         UnlockCart resolver integrates 6 framework and 5 module dependencies dictated
+         by Magento's DI pattern — no logical grouping can reduce this further. -->
+    <rule ref="rulesets/design.xml">
+        <exclude name="CouplingBetweenObjects"/>
+    </rule>
+    <rule ref="rulesets/design.xml/CouplingBetweenObjects">
+        <properties>
+            <property name="maximum" value="15"/>
+        </properties>
+    </rule>
+
+    <!--
+        Naming: relax length constraints.
+        - ShortVariable minimum → 2: allows $id in service/helper methods.
+        - LongVariable maximum → 30: Magento DI property names such as
+          $searchCriteriaBuilderFactory (29 chars) are dictated by the framework's
+          naming conventions and cannot be shortened without losing clarity.
+    -->
+    <rule ref="rulesets/naming.xml">
+        <exclude name="ShortVariable"/>
+        <exclude name="LongVariable"/>
+    </rule>
+    <rule ref="rulesets/naming.xml/ShortVariable">
+        <properties>
+            <property name="minimum" value="2"/>
+        </properties>
+    </rule>
+    <rule ref="rulesets/naming.xml/LongVariable">
+        <properties>
+            <property name="maximum" value="30"/>
+        </properties>
+    </rule>
+
+    <!--
+        Unused code: suppress UnusedFormalParameter.
+        Magento's ResolverInterface::resolve() mandates the full signature
+        ($field, $context, $info, $value, $args). Resolvers that don't use every
+        parameter still must declare them to satisfy the interface contract.
+        Plugin around/before/after methods similarly receive $subject/$proceed
+        even when not used directly.
+    -->
+    <rule ref="rulesets/unusedcode.xml">
+        <exclude name="UnusedFormalParameter"/>
+    </rule>
+
+</ruleset>

--- a/run-lint.sh
+++ b/run-lint.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# Runs PHPMD and/or PHPCS (Magento2 standard) for this module inside the
+# tapbuy-ci-php83 Docker image (same image used by `make test`).
+# Invoke via: make phpmd | make phpcs | make lint
+set -euo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
+IMAGE="tapbuy-ci-php83"
+TOOL="${1:-lint}"
+
+if ! docker image inspect "$IMAGE" > /dev/null 2>&1; then
+    echo "Building Docker image ${IMAGE} (first run only)..."
+    docker build -t "$IMAGE" "$SCRIPT_DIR"
+fi
+
+run_phpmd() {
+    echo ""
+    echo "========================================================="
+    echo " PHPMD -- $(basename "$SCRIPT_DIR")"
+    echo "========================================================="
+    docker run --rm \
+        -v "${SCRIPT_DIR}:/module:ro" \
+        "$IMAGE" \
+        bash -c "cd /module && phpmd . text cleancode,codesize,controversial,design,naming,unusedcode --exclude Test"
+}
+
+run_phpcs() {
+    echo ""
+    echo "========================================================="
+    echo " PHPCS (Magento2) -- $(basename "$SCRIPT_DIR")"
+    echo "========================================================="
+    docker run --rm \
+        -v "${SCRIPT_DIR}:/module:ro" \
+        "$IMAGE" \
+        bash -c "cd /module && phpcs -s --extensions=php ." \
+        | grep -v -E "^DEPRECATED|sniff is listening for"
+}
+
+case "$TOOL" in
+    phpmd) run_phpmd ;;
+    phpcs) run_phpcs ;;
+    lint)
+        # Run both tools; collect exit codes so both always run.
+        PHPMD_EXIT=0; PHPCS_EXIT=0
+        run_phpmd || PHPMD_EXIT=$?
+        run_phpcs || PHPCS_EXIT=$?
+        exit $(( PHPMD_EXIT | PHPCS_EXIT ))
+        ;;
+    *)
+        echo "Usage: $0 {phpmd|phpcs|lint}" >&2
+        exit 1
+        ;;
+esac

--- a/run-lint.sh
+++ b/run-lint.sh
@@ -21,7 +21,7 @@ run_phpmd() {
     docker run --rm \
         -v "${SCRIPT_DIR}:/module:ro" \
         "$IMAGE" \
-        bash -c "cd /module && phpmd . text cleancode,codesize,controversial,design,naming,unusedcode --exclude Test"
+        bash -c "cd /module && phpmd . text phpmd.xml --exclude Test"
 }
 
 run_phpcs() {

--- a/run-lint.sh
+++ b/run-lint.sh
@@ -33,7 +33,8 @@ run_phpcs() {
         -v "${SCRIPT_DIR}:/module:ro" \
         "$IMAGE" \
         bash -c "cd /module && phpcs -s --extensions=php ." \
-        | grep -v -E "^DEPRECATED|sniff is listening for"
+        | { grep -v -E "^DEPRECATED|sniff is listening for" || true; }
+    return "${PIPESTATUS[0]}"
 }
 
 case "$TOOL" in


### PR DESCRIPTION
This pull request introduces automated PHP code quality checks and refactors several resolvers for improved maintainability and clarity. It adds PHPMD and PHPCS (Magento2 standard) linting to both the CI workflow and local development, with supporting configuration and documentation. Additionally, it refactors resolver logic to extract and clarify complex conditions, improving readability and testability.

**Automated Code Quality & Linting:**

* Adds a GitHub Actions workflow (`.github/workflows/static-analysis.yml`) to run PHPMD and PHPCS on pushes and pull requests to main branches.
* Installs PHPMD, PHPCS, and Magento2 coding standard globally in the Docker image; updates `Makefile` and adds a `run-lint.sh` script to run these tools locally via `make lint`, `make phpmd`, or `make phpcs`. [[1]](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557R31-R39) [[2]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L1-R13) [[3]](diffhunk://#diff-36714de5903d68de233e39e4357fdc2fd8fd19c7ffebb25c3f8112d079622d94R1-R53)
* Adds configuration files for PHPMD (`phpmd.xml`) and PHPCS (`phpcs.xml`), with rules tailored for the Magento2 environment and project conventions. [[1]](diffhunk://#diff-86663aeec12838bb61855e163b38da1d1e38d18276b2d25c9dd6761127914a43R1-R81) [[2]](diffhunk://#diff-daa856500eea114bbf034fd35b7600050d965e5d19bb0700885c075747848fd8R1-R12)
* Updates `README.md` with instructions for running and understanding linting.

**Resolver Refactoring & Improvements:**

* Refactors `Model/Resolver/OrderAssignCustomer.php` by extracting logic for checking if an order is already assigned and for email compatibility into dedicated private methods, improving readability and maintainability. [[1]](diffhunk://#diff-9e88fcc9ed181eb71c874e6cb155c21edc52cf4327c99ade9b5bb1256f537635L96-R104) [[2]](diffhunk://#diff-9e88fcc9ed181eb71c874e6cb155c21edc52cf4327c99ade9b5bb1256f537635R171-R217)
* Refactors `Model/Resolver/ModulesVersions.php` to extract Tapbuy module version resolution into a helper method, and clarifies the Tapbuy module filter condition.
* Refactors `Model/Resolver/UnlockCart.php` to extract order cancellation logic into a private method, improving clarity and error handling when updating order status during cart unlock. [[1]](diffhunk://#diff-f691a6b674f33e9a739e3c68cd64214d014f08b870917c2b4ca61e22cf4c7c0eL110-R150) [[2]](diffhunk://#diff-f691a6b674f33e9a739e3c68cd64214d014f08b870917c2b4ca61e22cf4c7c0eL151-R179) [[3]](diffhunk://#diff-f691a6b674f33e9a739e3c68cd64214d014f08b870917c2b4ca61e22cf4c7c0eL165-L181)