### PR TITLE
PDT-480 Fix customer id type

### DIFF
--- a/Model/Resolver/Customer.php
+++ b/Model/Resolver/Customer.php
@@ -78,10 +78,11 @@ class Customer implements ResolverInterface
      * Get customer ID
      *
      * @param CustomerInterface $customer
-     * @return int
+     * @return int|null
      */
-    private function getCustomerId(CustomerInterface $customer): int
+    private function getCustomerId(CustomerInterface $customer): ?int
     {
-        return $customer->getId();
+        $id = $customer->getId();
+        return $id !== null ? (int) $id : null;
     }
 }

--- a/Test/Unit/Model/Resolver/CustomerTest.php
+++ b/Test/Unit/Model/Resolver/CustomerTest.php
@@ -89,4 +89,40 @@ class CustomerTest extends TestCase
 
         $this->assertNull($result);
     }
+
+    public function testReturnsNullWhenCustomerIdIsNull(): void
+    {
+        $this->config->method('isEnabled')->willReturn(true);
+        $this->field->method('getName')->willReturn('tapbuy_customer_id');
+
+        $customer = $this->createMock(CustomerInterface::class);
+        $customer->method('getId')->willReturn(null);
+
+        $result = $this->resolver->resolve(
+            $this->field,
+            $this->context,
+            $this->info,
+            ['model' => $customer]
+        );
+
+        $this->assertNull($result);
+    }
+
+    public function testCastsStringCustomerIdToInt(): void
+    {
+        $this->config->method('isEnabled')->willReturn(true);
+        $this->field->method('getName')->willReturn('tapbuy_customer_id');
+
+        $customer = $this->createMock(CustomerInterface::class);
+        $customer->method('getId')->willReturn('42');
+
+        $result = $this->resolver->resolve(
+            $this->field,
+            $this->context,
+            $this->info,
+            ['model' => $customer]
+        );
+
+        $this->assertSame(42, $result);
+    }
 }


### PR DESCRIPTION
This pull request makes a small change to the `getCustomerId` method in `Model/Resolver/Customer.php` to improve type safety and handle cases where a customer ID might be null.

* Changed the return type of `getCustomerId` from `int` to `int|null` and updated the implementation to explicitly cast the ID to an integer if it is not null, otherwise return null.